### PR TITLE
Disable older Rust CI bots.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [beta, stable, 1.45.0, 1.40.0, 1.38.0, 1.31.0]
+        rust: [beta, stable]
         os: [ubuntu]
         include:
           - rust: stable
@@ -42,9 +42,7 @@ jobs:
           toolchain: ${{matrix.rust}}
       - run: cargo check
       - run: cargo check --features preserve_order
-        if: matrix.rust != '1.31.0'
       - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc,preserve_order
-        if: matrix.rust != '1.31.0'
       - run: cargo check --features float_roundtrip
       - run: cargo check --features arbitrary_precision
       - run: cargo check --features raw_value


### PR DESCRIPTION
It seems that one of the dependencies, indexmap, has evolved
to require a more recent version of Rust than is tested on these bots.
Current consumers of serde_json_lenient do not need support on older
Rust versions, so abandon those bots.