### PR TITLE
Upgrade serde json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   schedule: [cron: "40 1 * * *"]
 
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   test:
     name: Rust nightly ${{matrix.os == 'windows' && '(windows)' || ''}}
@@ -14,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu, windows]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo test
       - run: cargo test --features preserve_order --tests -- --skip ui --exact
@@ -30,23 +33,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [beta, stable]
+        rust: [beta, stable, 1.53.0, 1.46.0, 1.45.0, 1.40.0, 1.38.0, 1.36.0]
         os: [ubuntu]
         include:
           - rust: stable
             os: windows
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
       - run: cargo check
-      - run: cargo check --features preserve_order
-      - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc,preserve_order
       - run: cargo check --features float_roundtrip
       - run: cargo check --features arbitrary_precision
       - run: cargo check --features raw_value
       - run: cargo check --features unbounded_depth
+      - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc
+      - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc,raw_value
+      - run: cargo check --features preserve_order
+        if: matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
+      - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc,preserve_order
+        if: matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
       - name: Build without std
         run: |
           rustup target add aarch64-unknown-none
@@ -57,29 +64,32 @@ jobs:
               --features alloc
         if: matrix.rust == 'stable' && matrix.os == 'ubuntu'
 
-  nostd:
-    name: Rust 1.36.0
+  miri:
+    name: Miri
     runs-on: ubuntu-latest
+    env:
+      MIRIFLAGS: -Zmiri-tag-raw-pointers
     steps:
-      - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@1.36.0
-      - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@miri
+      - run: cargo miri test
+      - run: cargo miri test --features preserve_order,float_roundtrip,arbitrary_precision,raw_value
 
-  #clippy:
-  #name: Clippy
-  #runs-on: ubuntu-latest
-  #if: github.event_name != 'pull_request'
-  #steps:
-  #- uses: actions/checkout@v2
-  #- uses: dtolnay/rust-toolchain@clippy
-  #- run: cargo clippy --tests -- -Dclippy::all -Dclippy::pedantic
-  #- run: cargo clippy --all-features --tests -- -Dclippy::all -Dclippy::pedantic
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@clippy
+      - run: cargo clippy --tests -- -Dclippy::all -Dclippy::pedantic
+      - run: cargo clippy --all-features --tests -- -Dclippy::all -Dclippy::pedantic
 
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo doc --features raw_value,unbounded_depth
         env:
@@ -89,7 +99,7 @@ jobs:
     name: Fuzz
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo install cargo-fuzz --debug
       - run: cargo fuzz build -O

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,20 @@ documentation = "https://docs.rs/serde_json_lenient/latest/"
 keywords = ["json", "serde", "serialization"]
 categories = ["encoding"]
 readme = "README.md"
-include = ["build.rs", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 edition = "2018"
-rust-version = "1.31"
+rust-version = "1.36"
 
 [dependencies]
 serde = { version = "1.0.100", default-features = false }
 indexmap = { version = "1.5", optional = true }
-itoa = { version = "0.4.3", default-features = false }
+itoa = "1.0"
 ryu = "1.0"
 
 [dev-dependencies]
 automod = "1.0"
+ref-cast = "1.0"
 rustversion = "1.0"
+serde = { version = "1.0.100", features = ["derive"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_stacker = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,12 @@ fn main() {
     if minor < 45 {
         println!("cargo:rustc-cfg=no_btreemap_remove_entry");
     }
+
+    // BTreeMap::retain
+    // https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#stabilized-apis
+    if minor < 53 {
+        println!("cargo:rustc-cfg=no_btreemap_retain");
+    }
 }
 
 fn rustc_minor_version() -> Option<u32> {

--- a/src/de.rs
+++ b/src/de.rs
@@ -1694,7 +1694,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     /// ```
     /// use serde_bytes::ByteBuf;
     ///
-    /// fn look_at_bytes() -> Result<(), serde_json::Error> {
+    /// fn look_at_bytes() -> Result<(), serde_json_lenient::Error> {
     ///     let json_data = b"\"lone surrogate: \\uD801\"";
     ///     let bytes: ByteBuf = serde_json_lenient::from_slice(json_data)?;
     ///     let expected = b"lone surrogate: \xED\xA0\x81";

--- a/src/de.rs
+++ b/src/de.rs
@@ -3,10 +3,16 @@
 use crate::error::{Error, ErrorCode, Result};
 #[cfg(feature = "float_roundtrip")]
 use crate::lexical;
-use crate::lib::str::FromStr;
-use crate::lib::*;
 use crate::number::Number;
 use crate::read::{self, Fused, Reference};
+use alloc::string::String;
+use alloc::vec::Vec;
+#[cfg(feature = "float_roundtrip")]
+use core::iter;
+use core::iter::FusedIterator;
+use core::marker::PhantomData;
+use core::result;
+use core::str::FromStr;
 use serde::de::{self, Expected, Unexpected};
 use serde::{forward_to_deserialize_any, serde_if_integer128};
 
@@ -97,7 +103,9 @@ impl<'a> Deserializer<read::StrRead<'a>> {
 
 macro_rules! overflow {
     ($a:ident * 10 + $b:ident, $c:expr) => {
-        $a >= $c / 10 && ($a > $c / 10 || $b > $c % 10)
+        match $c {
+            c => $a >= c / 10 && ($a > c / 10 || $b > c % 10),
+        }
     };
 }
 
@@ -946,6 +954,15 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             buf.push('-');
         }
         self.scan_integer(&mut buf)?;
+        if positive {
+            if let Ok(unsigned) = buf.parse() {
+                return Ok(ParserNumber::U64(unsigned));
+            }
+        } else {
+            if let Ok(signed) = buf.parse() {
+                return Ok(ParserNumber::I64(signed));
+            }
+        }
         Ok(ParserNumber::String(buf))
     }
 
@@ -1650,7 +1667,8 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     ///
     /// # Examples
     ///
-    /// You can use this to parse JSON strings containing invalid UTF-8 bytes.
+    /// You can use this to parse JSON strings containing invalid UTF-8 bytes,
+    /// or unpaired surrogates.
     ///
     /// ```
     /// use serde_bytes::ByteBuf;
@@ -1670,20 +1688,18 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     /// ```
     ///
     /// Backslash escape sequences like `\n` are still interpreted and required
-    /// to be valid, and `\u` escape sequences are required to represent valid
-    /// Unicode code points.
+    /// to be valid. `\u` escape sequences are required to represent a valid
+    /// Unicode code point or lone surrogate.
     ///
     /// ```
     /// use serde_bytes::ByteBuf;
     ///
-    /// fn look_at_bytes() {
-    ///     let json_data = b"\"invalid unicode surrogate: \\uD801\"";
-    ///     let parsed: Result<ByteBuf, _> = serde_json_lenient::from_slice(json_data);
-    ///
-    ///     assert!(parsed.is_err());
-    ///
-    ///     let expected_msg = "unexpected end of hex escape at line 1 column 34";
-    ///     assert_eq!(expected_msg, parsed.unwrap_err().to_string());
+    /// fn look_at_bytes() -> Result<(), serde_json::Error> {
+    ///     let json_data = b"\"lone surrogate: \\uD801\"";
+    ///     let bytes: ByteBuf = serde_json_lenient::from_slice(json_data)?;
+    ///     let expected = b"lone surrogate: \xED\xA0\x81";
+    ///     assert_eq!(expected, bytes.as_slice());
+    ///     Ok(())
     /// }
     /// #
     /// # look_at_bytes();
@@ -2315,10 +2331,18 @@ where
     }
 
     #[inline]
-    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
+        #[cfg(feature = "raw_value")]
+        {
+            if name == crate::raw::TOKEN {
+                return self.de.deserialize_raw_value(visitor);
+            }
+        }
+
+        let _ = name;
         visitor.visit_newtype_struct(self)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,14 @@
 //! When serializing or deserializing JSON goes wrong.
 
 use crate::io;
-use crate::lib::str::FromStr;
-use crate::lib::*;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use core::fmt::{self, Debug, Display};
+use core::result;
+use core::str::FromStr;
 use serde::{de, ser};
+#[cfg(feature = "std")]
+use std::error;
 
 /// This type represents all possible errors that can occur when serializing or
 /// deserializing JSON data.

--- a/src/io/core.rs
+++ b/src/io/core.rs
@@ -1,7 +1,9 @@
 //! Reimplements core logic and types from `std::io` in an `alloc`-friendly
 //! fashion.
 
-use crate::lib::*;
+use alloc::vec::Vec;
+use core::fmt::{self, Display};
+use core::result;
 
 pub enum ErrorKind {
     Other,

--- a/src/lexical/bhcomp.rs
+++ b/src/lexical/bhcomp.rs
@@ -12,7 +12,7 @@ use super::float::*;
 use super::math::*;
 use super::num::*;
 use super::rounding::*;
-use crate::lib::{cmp, mem};
+use core::{cmp, mem};
 
 // MANTISSA
 

--- a/src/lexical/bignum.rs
+++ b/src/lexical/bignum.rs
@@ -3,7 +3,7 @@
 //! Big integer type definition.
 
 use super::math::*;
-use crate::lib::Vec;
+use alloc::vec::Vec;
 
 /// Storage for a big integer type.
 #[derive(Clone, PartialEq, Eq)]

--- a/src/lexical/math.rs
+++ b/src/lexical/math.rs
@@ -9,7 +9,8 @@
 use super::large_powers;
 use super::num::*;
 use super::small_powers::*;
-use crate::lib::{cmp, iter, mem, Vec};
+use alloc::vec::Vec;
+use core::{cmp, iter, mem};
 
 // ALIASES
 // -------
@@ -593,7 +594,7 @@ mod large {
 
         // Iteratively add elements from y to x.
         let mut carry = false;
-        for (xi, yi) in (&mut x[xstart..]).iter_mut().zip(y.iter()) {
+        for (xi, yi) in x[xstart..].iter_mut().zip(y.iter()) {
             // Only one op of the two can overflow, since we added at max
             // Limb::max_value() + Limb::max_value(). Add the previous carry,
             // and store the current carry for the next.

--- a/src/lexical/num.rs
+++ b/src/lexical/num.rs
@@ -2,7 +2,7 @@
 
 //! Utilities for Rust numbers.
 
-use crate::lib::ops;
+use core::ops;
 
 /// Precalculated values of radix**i for i in range [0, arr.len()-1].
 /// Each value can be **exactly** represented as that type.

--- a/src/lexical/rounding.rs
+++ b/src/lexical/rounding.rs
@@ -5,7 +5,7 @@
 use super::float::ExtendedFloat;
 use super::num::*;
 use super::shift::*;
-use crate::lib::mem;
+use core::mem;
 
 // MASKS
 

--- a/src/lexical/shift.rs
+++ b/src/lexical/shift.rs
@@ -3,7 +3,7 @@
 //! Bit-shift helpers.
 
 use super::float::ExtendedFloat;
-use crate::lib::mem;
+use core::mem;
 
 // Shift extended-precision float right `shift` bytes.
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,10 +236,10 @@
 //! });
 //! ```
 //!
-//! This is amazingly convenient but we have the problem we had before with
-//! `Value` which is that the IDE and Rust compiler cannot help us if we get it
-//! wrong. Serde jsonrc provides a better way of serializing strongly-typed data
-//! structures into JSON text.
+//! This is amazingly convenient, but we have the problem we had before with
+//! `Value`: the IDE and Rust compiler cannot help us if we get it wrong. Serde
+//! JSON provides a better way of serializing strongly-typed data structures
+//! into JSON text.
 //!
 //! # Creating JSON by serializing data structures
 //!
@@ -312,6 +312,7 @@
 #![doc(html_root_url = "https://docs.rs/serde_json_lenient/0.1.4")]
 // Ignored clippy lints
 #![allow(
+    clippy::collapsible_else_if,
     clippy::comparison_chain,
     clippy::deprecated_cfg_attr,
     clippy::doc_markdown,
@@ -321,6 +322,10 @@
     clippy::match_like_matches_macro,
     clippy::match_single_binding,
     clippy::needless_doctest_main,
+    clippy::needless_late_init,
+    // clippy bug: https://github.com/rust-lang/rust-clippy/issues/8366
+    clippy::ptr_arg,
+    clippy::return_self_not_must_use,
     clippy::transmute_ptr_to_ptr,
     clippy::unnecessary_wraps,
     // clippy bug: https://github.com/rust-lang/rust-clippy/issues/5704
@@ -328,6 +333,8 @@
 )]
 // Ignored clippy_pedantic lints
 #![allow(
+    // buggy
+    clippy::iter_not_returning_iterator, // https://github.com/rust-lang/rust-clippy/issues/8285
     // Deserializer::from_str, into_iter
     clippy::should_implement_trait,
     // integer and float ser/de requires these sorts of casts
@@ -367,64 +374,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-////////////////////////////////////////////////////////////////////////////////
-
-#[cfg(not(feature = "std"))]
 extern crate alloc;
-
-/// A facade around all the types we need from the `std`, `core`, and `alloc`
-/// crates. This avoids elaborate import wrangling having to happen in every
-/// module.
-mod lib {
-    mod core {
-        #[cfg(not(feature = "std"))]
-        pub use core::*;
-        #[cfg(feature = "std")]
-        pub use std::*;
-    }
-
-    pub use self::core::cell::{Cell, RefCell};
-    pub use self::core::clone::{self, Clone};
-    pub use self::core::convert::{self, From, Into};
-    pub use self::core::default::{self, Default};
-    pub use self::core::fmt::{self, Debug, Display};
-    pub use self::core::hash::{self, Hash, Hasher};
-    pub use self::core::iter::FusedIterator;
-    pub use self::core::marker::{self, PhantomData};
-    pub use self::core::ops::{Bound, RangeBounds};
-    pub use self::core::result::{self, Result};
-    pub use self::core::{borrow, char, cmp, iter, mem, num, ops, slice, str};
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::borrow::{Cow, ToOwned};
-    #[cfg(feature = "std")]
-    pub use std::borrow::{Cow, ToOwned};
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::string::{String, ToString};
-    #[cfg(feature = "std")]
-    pub use std::string::{String, ToString};
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::vec::{self, Vec};
-    #[cfg(feature = "std")]
-    pub use std::vec::{self, Vec};
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::boxed::Box;
-    #[cfg(feature = "std")]
-    pub use std::boxed::Box;
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::collections::{btree_map, BTreeMap};
-    #[cfg(feature = "std")]
-    pub use std::collections::{btree_map, BTreeMap};
-
-    #[cfg(feature = "std")]
-    pub use std::error;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 
 #[cfg(feature = "std")]
 #[doc(inline)]
@@ -444,14 +394,11 @@ pub use crate::value::{from_value, to_value, Map, Number, Value};
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
 macro_rules! tri {
-    ($e:expr) => {
+    ($e:expr $(,)?) => {
         match $e {
-            crate::lib::Result::Ok(val) => val,
-            crate::lib::Result::Err(err) => return crate::lib::Result::Err(err),
+            core::result::Result::Ok(val) => val,
+            core::result::Result::Err(err) => return core::result::Result::Err(err),
         }
-    };
-    ($e:expr,) => {
-        tri!($e)
     };
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,12 +6,19 @@
 //! [`BTreeMap`]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
 //! [`IndexMap`]: https://docs.rs/indexmap/*/indexmap/map/struct.IndexMap.html
 
-use crate::lib::borrow::Borrow;
-use crate::lib::iter::FromIterator;
-use crate::lib::*;
 use crate::value::Value;
+use alloc::string::String;
+use core::borrow::Borrow;
+use core::fmt::{self, Debug};
+use core::hash::Hash;
+use core::iter::{FromIterator, FusedIterator};
+#[cfg(feature = "preserve_order")]
+use core::mem;
+use core::ops;
 use serde::de;
 
+#[cfg(not(feature = "preserve_order"))]
+use alloc::collections::{btree_map, BTreeMap};
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
 
@@ -94,6 +101,20 @@ impl Map<String, Value> {
         self.map.get_mut(key)
     }
 
+    /// Returns the key-value pair matching the given key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but the ordering
+    /// on the borrowed form *must* match the ordering on the key type.
+    #[inline]
+    #[cfg(any(feature = "preserve_order", not(no_btreemap_get_key_value)))]
+    pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&String, &Value)>
+    where
+        String: Borrow<Q>,
+        Q: ?Sized + Ord + Eq + Hash,
+    {
+        self.map.get_key_value(key)
+    }
+
     /// Inserts a key-value pair into the map.
     ///
     /// If the map did not have this key present, `None` is returned.
@@ -151,6 +172,8 @@ impl Map<String, Value> {
             no_btreemap_get_key_value,
         ))]
         {
+            use core::ops::{Bound, RangeBounds};
+
             struct Key<'a, Q: ?Sized>(&'a Q);
 
             impl<'a, Q: ?Sized> RangeBounds<Q> for Key<'a, Q> {
@@ -188,7 +211,7 @@ impl Map<String, Value> {
         S: Into<String>,
     {
         #[cfg(not(feature = "preserve_order"))]
-        use crate::lib::btree_map::Entry as EntryImpl;
+        use alloc::collections::btree_map::Entry as EntryImpl;
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -249,6 +249,19 @@ impl Map<String, Value> {
             iter: self.map.values_mut(),
         }
     }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)`
+    /// returns `false`.
+    #[cfg(not(no_btreemap_retain))]
+    #[inline]
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&String, &mut Value) -> bool,
+    {
+        self.map.retain(f);
+    }
 }
 
 #[allow(clippy::derivable_impls)] // clippy bug: https://github.com/rust-lang/rust-clippy/issues/7655

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,6 +1,8 @@
 use crate::de::ParserNumber;
 use crate::error::Error;
-use crate::lib::*;
+use core::fmt::{self, Debug, Display};
+#[cfg(not(feature = "arbitrary_precision"))]
+use core::hash::{Hash, Hasher};
 use serde::de::{self, Unexpected, Visitor};
 use serde::{
     forward_to_deserialize_any, serde_if_integer128, Deserialize, Deserializer, Serialize,
@@ -286,7 +288,7 @@ impl Number {
     }
 }
 
-impl fmt::Display for Number {
+impl Display for Number {
     #[cfg(not(feature = "arbitrary_precision"))]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self.n {

--- a/src/read.rs
+++ b/src/read.rs
@@ -1218,13 +1218,7 @@ where
             tri!(read.decode_hex_escape(4));
         }
         b'x' => {
-            let c: u32 = tri!(read.decode_hex_escape(2)).into();
-            match char::from_u32(c) {
-                Some(_) => {}
-                None => {
-                    return error(read, ErrorCode::InvalidUnicodeCodePoint);
-                }
-            };
+            tri!(read.decode_hex_escape(2));
         }
         _ => {
             return error(read, ErrorCode::InvalidEscape);

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,6 +1,9 @@
 use crate::error::{Error, ErrorCode, Result};
-use crate::lib::ops::Deref;
-use crate::lib::*;
+use alloc::vec::Vec;
+use core::char;
+use core::cmp;
+use core::ops::Deref;
+use core::str;
 
 #[cfg(feature = "std")]
 use crate::io;
@@ -389,7 +392,7 @@ where
                     return utf_strategy.to_result_simple(self, scratch);
                 }
                 b'\\' => {
-                    tri!(parse_escape(self, scratch));
+                    tri!(parse_escape(self, validate, scratch));
                 }
                 _ => {
                     if validate {
@@ -651,7 +654,7 @@ impl<'a> SliceRead<'a> {
                 b'\\' => {
                     utf_strategy.extend_scratch(scratch, &self.slice[start..self.index]);
                     self.index += 1;
-                    tri!(parse_escape(self, scratch));
+                    tri!(parse_escape(self, validate, scratch));
                     start = self.index;
                 }
                 _ => {
@@ -1042,17 +1045,12 @@ where
     }
 }
 
-fn next_expecting<'de, R: ?Sized + Read<'de>>(
-    read: &mut R,
-    expected: u8,
-    errcode: ErrorCode,
-) -> Result<u8> {
+fn peek_or_eof<'de, R>(read: &mut R) -> Result<u8>
+where
+    R: ?Sized + Read<'de>,
+{
     match tri!(read.peek()) {
-        Some(b) if b == expected => {
-            read.discard();
-            Ok(b)
-        }
-        Some(_) => error(read, errcode),
+        Some(b) => Ok(b),
         None => error(read, ErrorCode::EofWhileParsingString),
     }
 }
@@ -1065,8 +1063,8 @@ where
     Err(Error::syntax(reason, position.line, position.column))
 }
 
-fn parse_escape<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) -> Result<()> {
-    let r = parse_escape_or_fail(read, scratch);
+fn parse_escape<'de, R: Read<'de>>(read: &mut R, validate: bool, scratch: &mut Vec<u8>) -> Result<()> {
+    let r = parse_escape_or_fail(read, validate, scratch);
     if read.replace_invalid_unicode() {
         match r {
             Ok(a) => Ok(a),
@@ -1082,7 +1080,11 @@ fn parse_escape<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) -> Resul
 
 /// Parses a JSON escape sequence and appends it into the scratch space. Assumes
 /// the previous byte read was a backslash.
-fn parse_escape_or_fail<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) -> Result<()> {
+fn parse_escape_or_fail<'de, R: Read<'de>>(
+    read: &mut R,
+    validate: bool,
+    scratch: &mut Vec<u8>,
+) -> Result<()> {
     let ch = tri!(next_or_eof(read));
 
     match ch {
@@ -1106,27 +1108,60 @@ fn parse_escape_or_fail<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) 
             scratch.extend_from_slice(c.encode_utf8(&mut [0_u8; 4]).as_bytes());
         }
         b'u' => {
+            fn encode_surrogate(scratch: &mut Vec<u8>, n: u16) {
+                scratch.extend_from_slice(&[
+                    (n >> 12 & 0b0000_1111) as u8 | 0b1110_0000,
+                    (n >> 6 & 0b0011_1111) as u8 | 0b1000_0000,
+                    (n & 0b0011_1111) as u8 | 0b1000_0000,
+                ]);
+            }
+
             let c = match tri!(read.decode_hex_escape(4)) {
-                0xDC00..=0xDFFF => {
-                    return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
+                n @ 0xDC00..=0xDFFF => {
+                    return if validate {
+                        error(read, ErrorCode::LoneLeadingSurrogateInHexEscape)
+                    } else {
+                        encode_surrogate(scratch, n);
+                        Ok(())
+                    };
                 }
                 // Optionally, refuse to decode Unicode non-characters.
                 0xFDD0..=0xFDEF => '\u{fffd}',
                 n if (n & 0xFFFE == 0xFFFE || n == 0xFFFF) => '\u{fffd}',
 
-                // Non-BMP characters are encoded as a sequence of
-                // two hex escapes, representing UTF-16 surrogates.
+                // Non-BMP characters are encoded as a sequence of two hex
+                // escapes, representing UTF-16 surrogates. If deserializing a
+                // utf-8 string the surrogates are required to be paired,
+                // whereas deserializing a byte string accepts lone surrogates.
                 n1 @ 0xD800..=0xDBFF => {
-                    tri!(next_expecting(
-                        read,
-                        b'\\',
-                        ErrorCode::UnexpectedEndOfHexEscape
-                    ));
-                    tri!(next_expecting(
-                        read,
-                        b'u',
-                        ErrorCode::UnexpectedEndOfHexEscape
-                    ));
+                    if tri!(peek_or_eof(read)) == b'\\' {
+                        read.discard();
+                    } else {
+                        return if validate {
+                            read.discard();
+                            error(read, ErrorCode::UnexpectedEndOfHexEscape)
+                        } else {
+                            encode_surrogate(scratch, n1);
+                            Ok(())
+                        };
+                    }
+
+                    if tri!(peek_or_eof(read)) == b'u' {
+                        read.discard();
+                    } else {
+                        return if validate {
+                            read.discard();
+                            error(read, ErrorCode::UnexpectedEndOfHexEscape)
+                        } else {
+                            encode_surrogate(scratch, n1);
+                            // The \ prior to this byte started an escape sequence,
+                            // so we need to parse that now. This recursive call
+                            // does not blow the stack on malicious input because
+                            // the escape is not \u, so it will be handled by one
+                            // of the easy nonrecursive cases.
+                            parse_escape(read, validate, scratch)
+                        };
+                    }
 
                     let n2 = tri!(read.decode_hex_escape(4));
 
@@ -1148,12 +1183,9 @@ fn parse_escape_or_fail<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) 
                     }
                 }
 
-                n => match char::from_u32(n as u32) {
-                    Some(c) => c,
-                    None => {
-                        return error(read, ErrorCode::InvalidUnicodeCodePoint);
-                    }
-                },
+                // Every u16 outside of the surrogate ranges above is guaranteed
+                // to be a legal char.
+                n => char::from_u32(n as u32).unwrap(),
             };
 
             scratch.extend_from_slice(c.encode_utf8(&mut [0_u8; 4]).as_bytes());
@@ -1177,36 +1209,13 @@ where
     match ch {
         b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' | b'v' => {}
         b'u' => {
-            let n = match tri!(read.decode_hex_escape(4)) {
-                0xDC00..=0xDFFF => {
-                    return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
-                }
+            // At this point we don't care if the codepoint is valid. We just
+            // want to consume it. We don't actually know what is valid or not
+            // at this point, because that depends on if this string will
+            // ultimately be parsed into a string or a byte buffer in the "real"
+            // parse.
 
-                // Non-BMP characters are encoded as a sequence of
-                // two hex escapes, representing UTF-16 surrogates.
-                n1 @ 0xD800..=0xDBFF => {
-                    if tri!(next_or_eof(read)) != b'\\' {
-                        return error(read, ErrorCode::UnexpectedEndOfHexEscape);
-                    }
-                    if tri!(next_or_eof(read)) != b'u' {
-                        return error(read, ErrorCode::UnexpectedEndOfHexEscape);
-                    }
-
-                    let n2 = tri!(read.decode_hex_escape(4));
-
-                    if n2 < 0xDC00 || n2 > 0xDFFF {
-                        return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
-                    }
-
-                    (((n1 - 0xD800) as u32) << 10 | (n2 - 0xDC00) as u32) + 0x1_0000
-                }
-
-                n => n as u32,
-            };
-
-            if char::from_u32(n).is_none() {
-                return error(read, ErrorCode::InvalidUnicodeCodePoint);
-            }
+            tri!(read.decode_hex_escape(4));
         }
         b'x' => {
             let c: u32 = tri!(read.decode_hex_escape(2)).into();

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2,8 +2,10 @@
 
 use crate::error::{Error, ErrorCode, Result};
 use crate::io;
-use crate::lib::num::FpCategory;
-use crate::lib::*;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt::{self, Display};
+use core::num::FpCategory;
 use serde::ser::{self, Impossible, Serialize};
 use serde::serde_if_integer128;
 
@@ -1545,6 +1547,13 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Display,
+    {
+        self.serialize_str(&value.to_string())
     }
 }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,9 +1,15 @@
 use crate::error::Error;
-use crate::lib::str::FromStr;
-use crate::lib::*;
 use crate::map::Map;
 use crate::number::Number;
 use crate::value::Value;
+use alloc::borrow::{Cow, ToOwned};
+use alloc::string::String;
+#[cfg(feature = "raw_value")]
+use alloc::string::ToString;
+use alloc::vec::{self, Vec};
+use core::fmt;
+use core::slice;
+use core::str::FromStr;
 use serde::de::{
     self, Deserialize, DeserializeSeed, EnumAccess, Expected, IntoDeserializer, MapAccess,
     SeqAccess, Unexpected, VariantAccess, Visitor,

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,8 +1,10 @@
 use super::Value;
-use crate::lib::iter::FromIterator;
-use crate::lib::*;
 use crate::map::Map;
 use crate::number::Number;
+use alloc::borrow::Cow;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::iter::FromIterator;
 
 #[cfg(feature = "arbitrary_precision")]
 use serde::serde_if_integer128;

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,6 +1,9 @@
 use super::Value;
-use crate::lib::*;
 use crate::map::Map;
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use core::fmt::{self, Display};
+use core::ops;
 
 /// A type that can be used to index into a `serde_json_lenient::Value`.
 ///
@@ -133,14 +136,14 @@ mod private {
     pub trait Sealed {}
     impl Sealed for usize {}
     impl Sealed for str {}
-    impl Sealed for super::String {}
+    impl Sealed for alloc::string::String {}
     impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
 }
 
 /// Used in panic messages.
 struct Type<'a>(&'a Value);
 
-impl<'a> fmt::Display for Type<'a> {
+impl<'a> Display for Type<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match *self.0 {
             Value::Null => formatter.write_str("null"),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -92,7 +92,11 @@
 
 use crate::error::Error;
 use crate::io;
-use crate::lib::*;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt::{self, Debug, Display};
+use core::mem;
+use core::str;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
@@ -191,7 +195,7 @@ impl Debug for Value {
     }
 }
 
-impl fmt::Display for Value {
+impl Display for Value {
     /// Display a JSON value as a string.
     ///
     /// ```

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,5 +1,5 @@
 use super::Value;
-use crate::lib::*;
+use alloc::string::String;
 
 fn eq_i64(value: &Value, other: i64) -> bool {
     value.as_i64().map_or(false, |i| i == other)

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,8 +1,12 @@
 use crate::error::{Error, ErrorCode, Result};
-use crate::lib::*;
 use crate::map::Map;
 use crate::number::Number;
 use crate::value::{to_value, Value};
+use alloc::borrow::ToOwned;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt::Display;
+use core::result;
 use serde::ser::{Impossible, Serialize};
 
 #[cfg(feature = "arbitrary_precision")]
@@ -1015,5 +1019,12 @@ impl serde::ser::Serializer for RawValueEmitter {
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         Err(invalid_raw_value())
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Display,
+    {
+        self.serialize_str(&value.to_string())
     }
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,4 +1,5 @@
 #[rustversion::attr(not(nightly), ignore)]
+#[cfg_attr(miri, ignore)]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/tests/invalid_characters.rs
+++ b/tests/invalid_characters.rs
@@ -26,11 +26,7 @@ fn test_invalid_characters() {
 
 #[test]
 fn test_invalid_utf16_escape_sequence() {
-    let s = r#"
-    {
-        "key": "value\ud800"
-    }"#
-    .as_bytes();
+    let s = "{\"key\": \"value\\udfff\"}".as_bytes();
     let value: Value = from_slice_with_unicode_substitution(&s).unwrap();
     assert_eq!(value, json!({"key": "value\u{fffd}"}));
 }

--- a/tests/lexical.rs
+++ b/tests/lexical.rs
@@ -10,6 +10,7 @@
     clippy::float_cmp,
     clippy::if_not_else,
     clippy::module_name_repetitions,
+    clippy::needless_late_init,
     clippy::shadow_unrelated,
     clippy::similar_names,
     clippy::single_match_else,
@@ -18,6 +19,8 @@
     clippy::unseparated_literal_suffix,
     clippy::wildcard_imports
 )]
+
+extern crate alloc;
 
 #[path = "../src/lexical/mod.rs"]
 mod lexical;

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -34,3 +34,14 @@ fn test_append() {
     assert_eq!(keys, EXPECTED);
     assert!(val.is_empty());
 }
+
+#[cfg(not(no_btreemap_retain))]
+#[test]
+fn test_retain() {
+    let mut v: Value = from_str(r#"{"b":null,"a":null,"c":null}"#).unwrap();
+    let val = v.as_object_mut().unwrap();
+    val.retain(|k, _| k.as_str() != "b");
+
+    let keys: Vec<_> = val.keys().collect();
+    assert_eq!(keys, &["a", "c"]);
+}

--- a/tests/regression/issue845.rs
+++ b/tests/regression/issue845.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Deserializer};
+use std::convert::TryFrom;
+use std::fmt::{self, Display};
+use std::marker::PhantomData;
+use std::str::FromStr;
+
+pub struct NumberVisitor<T> {
+    marker: PhantomData<T>,
+}
+
+impl<'de, T> serde::de::Visitor<'de> for NumberVisitor<T>
+where
+    T: TryFrom<u64> + TryFrom<i64> + FromStr,
+    <T as TryFrom<u64>>::Error: Display,
+    <T as TryFrom<i64>>::Error: Display,
+    <T as FromStr>::Err: Display,
+{
+    type Value = T;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an integer or string")
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        T::try_from(v).map_err(serde::de::Error::custom)
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        T::try_from(v).map_err(serde::de::Error::custom)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        v.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+fn deserialize_integer_or_string<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: TryFrom<u64> + TryFrom<i64> + FromStr,
+    <T as TryFrom<u64>>::Error: Display,
+    <T as TryFrom<i64>>::Error: Display,
+    <T as FromStr>::Err: Display,
+{
+    deserializer.deserialize_any(NumberVisitor {
+        marker: PhantomData,
+    })
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Struct {
+    #[serde(deserialize_with = "deserialize_integer_or_string")]
+    pub i: i64,
+}
+
+#[test]
+fn test() {
+    let j = r#" {"i":100} "#;
+    println!("{:?}", serde_json::from_str::<Struct>(j).unwrap());
+
+    let j = r#" {"i":"100"} "#;
+    println!("{:?}", serde_json::from_str::<Struct>(j).unwrap());
+}

--- a/tests/regression/issue845.rs
+++ b/tests/regression/issue845.rs
@@ -65,8 +65,8 @@ pub struct Struct {
 #[test]
 fn test() {
     let j = r#" {"i":100} "#;
-    println!("{:?}", serde_json::from_str::<Struct>(j).unwrap());
+    println!("{:?}", serde_json_lenient::from_str::<Struct>(j).unwrap());
 
     let j = r#" {"i":"100"} "#;
-    println!("{:?}", serde_json::from_str::<Struct>(j).unwrap());
+    println!("{:?}", serde_json_lenient::from_str::<Struct>(j).unwrap());
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1607,7 +1607,7 @@ fn test_serialize_map_with_no_len() {
 #[cfg(not(miri))]
 #[test]
 fn test_deserialize_from_stream() {
-    use serde_json::to_writer;
+    use serde_json_lenient::to_writer;
     use std::net::{TcpListener, TcpStream};
     use std::thread;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -19,21 +19,28 @@ trace_macros!(true);
 #[macro_use]
 mod macros;
 
+#[cfg(feature = "raw_value")]
+use ref_cast::RefCast;
 use serde::de::{self, IgnoredAny, IntoDeserializer};
-use serde::ser::{self, Serializer};
+use serde::ser::{self, SerializeMap, SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
 use serde_bytes::{ByteBuf, Bytes};
+#[cfg(feature = "raw_value")]
+use serde_json_lenient::value::RawValue;
 use serde_json_lenient::{
     from_reader, from_slice, from_str, from_value, json, to_string, to_string_pretty, to_value,
-    to_vec, to_writer, Deserializer, Number, Value,
+    to_vec, Deserializer, Number, Value,
 };
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
+#[cfg(feature = "raw_value")]
+use std::collections::HashMap;
 use std::fmt::{self, Debug};
 use std::hash::{Hash, Hasher};
 use std::io;
 use std::iter;
 use std::marker::PhantomData;
+use std::mem;
 use std::str::FromStr;
 use std::string::ToString;
 use std::{f32, f64};
@@ -712,11 +719,7 @@ fn test_parse_char() {
         ),
         (
             "10",
-            if cfg!(feature = "arbitrary_precision") {
-                "invalid type: number, expected a character at line 1 column 2"
-            } else {
-                "invalid type: integer `10`, expected a character at line 1 column 2"
-            },
+            "invalid type: integer `10`, expected a character at line 1 column 2",
         ),
     ]);
 
@@ -1187,11 +1190,7 @@ fn test_parse_struct() {
     test_parse_err::<Outer>(&[
         (
             "5",
-            if cfg!(feature = "arbitrary_precision") {
-                "invalid type: number, expected struct Outer at line 1 column 1"
-            } else {
-                "invalid type: integer `5`, expected struct Outer at line 1 column 1"
-            },
+            "invalid type: integer `5`, expected struct Outer at line 1 column 1",
         ),
         (
             "\"hello\"",
@@ -1443,7 +1442,6 @@ fn test_serialize_seq_with_no_len() {
         where
             S: ser::Serializer,
         {
-            use serde::ser::SerializeSeq;
             let mut seq = serializer.serialize_seq(None)?;
             for elem in &self.0 {
                 seq.serialize_element(elem)?;
@@ -1530,7 +1528,6 @@ fn test_serialize_map_with_no_len() {
         where
             S: ser::Serializer,
         {
-            use serde::ser::SerializeMap;
             let mut map = serializer.serialize_map(None)?;
             for (k, v) in &self.0 {
                 map.serialize_entry(k, v)?;
@@ -1607,10 +1604,11 @@ fn test_serialize_map_with_no_len() {
     assert_eq!(s, expected);
 }
 
+#[cfg(not(miri))]
 #[test]
 fn test_deserialize_from_stream() {
-    use serde::Deserialize;
-    use std::net;
+    use serde_json::to_writer;
+    use std::net::{TcpListener, TcpStream};
     use std::thread;
 
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -1618,7 +1616,7 @@ fn test_deserialize_from_stream() {
         message: String,
     }
 
-    let l = net::TcpListener::bind("localhost:20000").unwrap();
+    let l = TcpListener::bind("localhost:20000").unwrap();
 
     thread::spawn(|| {
         let l = l;
@@ -1635,7 +1633,7 @@ fn test_deserialize_from_stream() {
         }
     });
 
-    let mut stream = net::TcpStream::connect("localhost:20000").unwrap();
+    let mut stream = TcpStream::connect("localhost:20000").unwrap();
     let request = Message {
         message: "hi there".to_string(),
     };
@@ -1702,6 +1700,48 @@ fn test_byte_buf_de() {
 }
 
 #[test]
+fn test_byte_buf_de_lone_surrogate() {
+    let bytes = ByteBuf::from(vec![237, 160, 188]);
+    let v: ByteBuf = from_str(r#""\ud83c""#).unwrap();
+    assert_eq!(v, bytes);
+
+    let bytes = ByteBuf::from(vec![237, 160, 188, 10]);
+    let v: ByteBuf = from_str(r#""\ud83c\n""#).unwrap();
+    assert_eq!(v, bytes);
+
+    let bytes = ByteBuf::from(vec![237, 160, 188, 32]);
+    let v: ByteBuf = from_str(r#""\ud83c ""#).unwrap();
+    assert_eq!(v, bytes);
+
+    let bytes = ByteBuf::from(vec![237, 176, 129]);
+    let v: ByteBuf = from_str(r#""\udc01""#).unwrap();
+    assert_eq!(v, bytes);
+
+    let res = from_str::<ByteBuf>(r#""\ud83c\!""#);
+    assert!(res.is_err());
+
+    let res = from_str::<ByteBuf>(r#""\ud83c\u""#);
+    assert!(res.is_err());
+
+    let res = from_str::<ByteBuf>(r#""\ud83c\ud83c""#);
+    assert!(res.is_err());
+}
+
+#[cfg(feature = "raw_value")]
+#[test]
+fn test_raw_de_lone_surrogate() {
+    use serde_json::value::RawValue;
+
+    assert!(from_str::<Box<RawValue>>(r#""\ud83c""#).is_ok());
+    assert!(from_str::<Box<RawValue>>(r#""\ud83c\n""#).is_ok());
+    assert!(from_str::<Box<RawValue>>(r#""\ud83c ""#).is_ok());
+    assert!(from_str::<Box<RawValue>>(r#""\udc01 ""#).is_ok());
+    assert!(from_str::<Box<RawValue>>(r#""\udc01\!""#).is_err());
+    assert!(from_str::<Box<RawValue>>(r#""\udc01\u""#).is_err());
+    assert!(from_str::<Box<RawValue>>(r#""\ud83c\ud83c""#).is_ok());
+}
+
+#[test]
 fn test_byte_buf_de_multiple() {
     let s: Vec<ByteBuf> = from_str(r#"["ab\nc", "cd\ne"]"#).unwrap();
     let a = ByteBuf::from(b"ab\nc".to_vec());
@@ -1748,8 +1788,6 @@ fn test_json_pointer() {
 
 #[test]
 fn test_json_pointer_mut() {
-    use std::mem;
-
     // Test case taken from https://tools.ietf.org/html/rfc6901#page-5
     let mut data: Value = from_str(
         r#"{
@@ -2131,8 +2169,6 @@ fn test_integer128() {
 #[cfg(feature = "raw_value")]
 #[test]
 fn test_borrowed_raw_value() {
-    use serde_json_lenient::value::RawValue;
-
     #[derive(Serialize, Deserialize)]
     struct Wrapper<'a> {
         a: i8,
@@ -2164,9 +2200,45 @@ fn test_borrowed_raw_value() {
 
 #[cfg(feature = "raw_value")]
 #[test]
-fn test_boxed_raw_value() {
-    use serde_json_lenient::value::RawValue;
+fn test_raw_value_in_map_key() {
+    #[derive(RefCast)]
+    #[repr(transparent)]
+    struct RawMapKey(RawValue);
 
+    impl<'de> Deserialize<'de> for &'de RawMapKey {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let raw_value = <&RawValue>::deserialize(deserializer)?;
+            Ok(RawMapKey::ref_cast(raw_value))
+        }
+    }
+
+    impl PartialEq for RawMapKey {
+        fn eq(&self, other: &Self) -> bool {
+            self.0.get() == other.0.get()
+        }
+    }
+
+    impl Eq for RawMapKey {}
+
+    impl Hash for RawMapKey {
+        fn hash<H: Hasher>(&self, hasher: &mut H) {
+            self.0.get().hash(hasher);
+        }
+    }
+
+    let map_from_str: HashMap<&RawMapKey, &RawValue> =
+        serde_json::from_str(r#" {"\\k":"\\v"} "#).unwrap();
+    let (map_k, map_v) = map_from_str.into_iter().next().unwrap();
+    assert_eq!("\"\\\\k\"", map_k.0.get());
+    assert_eq!("\"\\\\v\"", map_v.get());
+}
+
+#[cfg(feature = "raw_value")]
+#[test]
+fn test_boxed_raw_value() {
     #[derive(Serialize, Deserialize)]
     struct Wrapper {
         a: i8,
@@ -2213,8 +2285,6 @@ fn test_boxed_raw_value() {
 #[cfg(feature = "raw_value")]
 #[test]
 fn test_raw_invalid_utf8() {
-    use serde_json_lenient::value::RawValue;
-
     let j = &[b'"', b'\xCE', b'\xF8', b'"'];
     let value_err = serde_json_lenient::from_slice::<Value>(j).unwrap_err();
     let raw_value_err = serde_json_lenient::from_slice::<Box<RawValue>>(j).unwrap_err();
@@ -2226,6 +2296,15 @@ fn test_raw_invalid_utf8() {
     assert_eq!(
         raw_value_err.to_string(),
         "invalid unicode code point at line 1 column 4",
+    );
+}
+
+#[cfg(feature = "raw_value")]
+#[test]
+fn test_serialize_unsized_value_to_raw_value() {
+    assert_eq!(
+        serde_json::value::to_raw_value("foobar").unwrap().get(),
+        r#""foobar""#,
     );
 }
 


### PR DESCRIPTION
Upgrade serde_json to v1.0.80 primarily to solve continuous CI fails with older serde_json versions and modern rust.

This also:
* fixes a serde_json_lenient test which appears to have always been wrong
* removes a previous change which disabled clippy from CI