### PR TITLE
Upgrade serde json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
   schedule: [cron: "40 1 * * *"]
 
+permissions:
+  contents: read
+
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   test:
     name: Rust nightly ${{matrix.os == 'windows' && '(windows)' || ''}}
@@ -13,8 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows]
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo test
       - run: cargo test --features preserve_order --tests -- --skip ui --exact
@@ -30,56 +37,67 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [beta, stable]
+        rust: [beta, 1.56.1]
         os: [ubuntu]
         include:
           - rust: stable
+            os: ubuntu
+            target: aarch64-unknown-none
+          - rust: stable
             os: windows
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
+          targets: ${{matrix.target}}
       - run: cargo check
-      - run: cargo check --features preserve_order
-      - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc,preserve_order
       - run: cargo check --features float_roundtrip
       - run: cargo check --features arbitrary_precision
       - run: cargo check --features raw_value
       - run: cargo check --features unbounded_depth
-      - name: Build without std
-        run: |
-          rustup target add aarch64-unknown-none
-          cargo check \
-              --manifest-path tests/crate/Cargo.toml \
-              --target aarch64-unknown-none \
-              --no-default-features \
-              --features alloc
-        if: matrix.rust == 'stable' && matrix.os == 'ubuntu'
-
-  nostd:
-    name: Rust 1.36.0
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@1.36.0
       - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc
+      - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc,arbitrary_precision
+      - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc,raw_value
+      - run: cargo check --features preserve_order
+        if: matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
+      - run: cargo check --manifest-path tests/crate/Cargo.toml --no-default-features --features alloc,preserve_order
+        if: matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
+      - name: Build without std
+        run: cargo check --manifest-path tests/crate/Cargo.toml --target ${{matrix.target}} --no-default-features --features alloc
+        if: matrix.target
 
-  #clippy:
-  #name: Clippy
-  #runs-on: ubuntu-latest
-  #if: github.event_name != 'pull_request'
-  #steps:
-  #- uses: actions/checkout@v2
-  #- uses: dtolnay/rust-toolchain@clippy
-  #- run: cargo clippy --tests -- -Dclippy::all -Dclippy::pedantic
-  #- run: cargo clippy --all-features --tests -- -Dclippy::all -Dclippy::pedantic
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    env:
+      MIRIFLAGS: -Zmiri-strict-provenance
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@miri
+      - run: cargo miri setup
+      - run: cargo miri test
+      - run: cargo miri test --features preserve_order,float_roundtrip,arbitrary_precision,raw_value
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@clippy
+      - run: cargo clippy --tests -- -Dclippy::all -Dclippy::pedantic
+      - run: cargo clippy --all-features --tests -- -Dclippy::all -Dclippy::pedantic
 
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo doc --features raw_value,unbounded_depth
         env:
@@ -88,8 +106,20 @@ jobs:
   fuzz:
     name: Fuzz
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo install cargo-fuzz --debug
-      - run: cargo fuzz build -O
+      - uses: dtolnay/install@cargo-fuzz
+      - run: cargo fuzz check
+
+  outdated:
+    name: Outdated
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/install@cargo-outdated
+      - run: cargo outdated --workspace --exit-code 1
+      - run: cargo outdated --manifest-path fuzz/Cargo.toml --exit-code 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,22 +11,25 @@ license = "MIT/Apache-2.0"
 description = "A lenient JSON serialization file format"
 repository = "https://github.com/google/serde_json_lenient"
 documentation = "https://docs.rs/serde_json_lenient/latest/"
-keywords = ["json", "serde", "serialization"]
-categories = ["encoding"]
+categories = ["encoding", "parser-implementations", "no-std"]
 readme = "README.md"
 include = ["build.rs", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 edition = "2018"
-rust-version = "1.31"
+keywords = ["json", "serde", "serialization"]
+rust-version = "1.36"
 
 [dependencies]
 serde = { version = "1.0.100", default-features = false }
-indexmap = { version = "1.5", optional = true }
-itoa = { version = "0.4.3", default-features = false }
+indexmap = { version = "1.5.2", features = ["std"], optional = true }
+itoa = "1.0"
 ryu = "1.0"
 
 [dev-dependencies]
 automod = "1.0"
+indoc = "2.0"
+ref-cast = "1.0"
 rustversion = "1.0"
+serde = { version = "1.0.100", features = ["derive"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_stacker = "0.1"
@@ -34,6 +37,9 @@ trybuild = { version = "1.0.49", features = ["diff"] }
 
 [workspace]
 members = ["tests/crate"]
+
+[lib]
+doc-scrape-examples = false
 
 [package.metadata.docs.rs]
 features = ["raw_value", "unbounded_depth"]
@@ -54,13 +60,12 @@ std = ["serde/std"]
 # Provide integration for heap-allocated collections without depending on the
 # rest of the Rust standard library.
 # NOTE: Disabling both `std` *and* `alloc` features is not supported yet.
-# Available on Rust 1.36+.
 alloc = ["serde/alloc"]
 
 # Make serde_json::Map use a representation which maintains insertion order.
 # This allows data to be read into a Value and written back to a JSON string
 # while preserving the order of map keys in the input.
-preserve_order = ["indexmap"]
+preserve_order = ["indexmap", "std"]
 
 # Use sufficient precision when parsing fixed precision floats from JSON to
 # ensure that they maintain accuracy when round-tripped through JSON. This comes

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -174,28 +174,3 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
    of your accepting any such warranty or additional liability.
 
 END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets "[]"
-   replaced with your own identifying information. (Don't include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same "printed page" as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# serde_json_lenient
+# serde_json_lenient &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![Rustc Version 1.36+]][rustc]
+
+[Build Status]: https://img.shields.io/github/actions/workflow/status/google/serde_json_lenient/ci.yml?branch=master
+[actions]: https://github.com/google/serde_json_lenient/actions?query=branch%3Amaster
+[Latest Version]: https://img.shields.io/crates/v/serde_json_lenient.svg
+[crates.io]: https://crates.io/crates/serde\_json\_lenient
+[Rustc Version 1.36+]: https://img.shields.io/badge/rustc-1.36+-lightgray.svg
+[rustc]: https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html
 
 This is a lenient JSON parser forked from the
 [serde_json](https://crates.io/crates/serde_json) crate

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,8 @@ use std::process::Command;
 use std::str::{self, FromStr};
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
     // Decide ideal limb width for arithmetic in the float parser. Refer to
     // src/lexical/math.rs for where this has an effect.
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
@@ -30,6 +32,12 @@ fn main() {
     // https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#library-changes
     if minor < 45 {
         println!("cargo:rustc-cfg=no_btreemap_remove_entry");
+    }
+
+    // BTreeMap::retain
+    // https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#stabilized-apis
+    if minor < 53 {
+        println!("cargo:rustc-cfg=no_btreemap_retain");
     }
 }
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,3 +1,4 @@
 artifacts/
 corpus/
+coverage/
 target/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "serde_json_lenient-fuzz"
 version = "0.0.0"
-authors = ["David Korczynski <david@adalogics.com>"]
+authors = ["David Tolnay <dtolnay@gmail.com>"]
+edition = "2021"
 publish = false
-edition = "2018"
 
 [package.metadata]
 cargo-fuzz = true
@@ -15,6 +15,7 @@ serde_json_lenient = { path = ".." }
 [[bin]]
 name = "from_slice"
 path = "fuzz_targets/from_slice.rs"
+test = false
+doc = false
 
-# Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/from_slice.rs
+++ b/fuzz/fuzz_targets/from_slice.rs
@@ -4,5 +4,5 @@ use libfuzzer_sys::fuzz_target;
 use serde_json_lenient::{from_slice, Value};
 
 fuzz_target!(|data: &[u8]| {
-    let _ = from_slice::<Value>(data);
+    _ = from_slice::<Value>(data);
 });

--- a/src/de.rs
+++ b/src/de.rs
@@ -3,12 +3,18 @@
 use crate::error::{Error, ErrorCode, Result};
 #[cfg(feature = "float_roundtrip")]
 use crate::lexical;
-use crate::lib::str::FromStr;
-use crate::lib::*;
 use crate::number::Number;
 use crate::read::{self, Fused, Reference};
+use alloc::string::String;
+use alloc::vec::Vec;
+#[cfg(feature = "float_roundtrip")]
+use core::iter;
+use core::iter::FusedIterator;
+use core::marker::PhantomData;
+use core::result;
+use core::str::FromStr;
 use serde::de::{self, Expected, Unexpected};
-use serde::{forward_to_deserialize_any, serde_if_integer128};
+use serde::forward_to_deserialize_any;
 
 #[cfg(feature = "arbitrary_precision")]
 use crate::number::NumberDeserializer;
@@ -97,7 +103,9 @@ impl<'a> Deserializer<read::StrRead<'a>> {
 
 macro_rules! overflow {
     ($a:ident * 10 + $b:ident, $c:expr) => {
-        $a >= $c / 10 && ($a > $c / 10 || $b > $c % 10)
+        match $c {
+            c => $a >= c / 10 && ($a > c / 10 || $b > c % 10),
+        }
     };
 }
 
@@ -417,31 +425,25 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
-    serde_if_integer128! {
-        fn scan_integer128(&mut self, buf: &mut String) -> Result<()> {
-            match tri!(self.next_char_or_null()) {
-                b'0' => {
-                    buf.push('0');
-                    // There can be only one leading '0'.
-                    match tri!(self.peek_or_null()) {
-                        b'0'..=b'9' => {
-                            Err(self.peek_error(ErrorCode::InvalidNumber))
-                        }
-                        _ => Ok(()),
-                    }
-                }
-                c @ b'1'..=b'9' => {
-                    buf.push(c as char);
-                    while let c @ b'0'..=b'9' = tri!(self.peek_or_null()) {
-                        self.eat_char();
-                        buf.push(c as char);
-                    }
-                    Ok(())
-                }
-                _ => {
-                    Err(self.error(ErrorCode::InvalidNumber))
+    fn scan_integer128(&mut self, buf: &mut String) -> Result<()> {
+        match tri!(self.next_char_or_null()) {
+            b'0' => {
+                buf.push('0');
+                // There can be only one leading '0'.
+                match tri!(self.peek_or_null()) {
+                    b'0'..=b'9' => Err(self.peek_error(ErrorCode::InvalidNumber)),
+                    _ => Ok(()),
                 }
             }
+            c @ b'1'..=b'9' => {
+                buf.push(c as char);
+                while let c @ b'0'..=b'9' = tri!(self.peek_or_null()) {
+                    self.eat_char();
+                    buf.push(c as char);
+                }
+                Ok(())
+            }
+            _ => Err(self.error(ErrorCode::InvalidNumber)),
         }
     }
 
@@ -539,30 +541,33 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         &mut self,
         positive: bool,
         mut significand: u64,
-        mut exponent: i32,
+        exponent_before_decimal_point: i32,
     ) -> Result<f64> {
         self.eat_char();
 
+        let mut exponent_after_decimal_point = 0;
         while let c @ b'0'..=b'9' = tri!(self.peek_or_null()) {
             let digit = (c - b'0') as u64;
 
             if overflow!(significand * 10 + digit, u64::max_value()) {
+                let exponent = exponent_before_decimal_point + exponent_after_decimal_point;
                 return self.parse_decimal_overflow(positive, significand, exponent);
             }
 
             self.eat_char();
             significand = significand * 10 + digit;
-            exponent -= 1;
+            exponent_after_decimal_point -= 1;
         }
 
         // Error if there is not at least one digit after the decimal point.
-        if exponent == 0 {
+        if exponent_after_decimal_point == 0 {
             match tri!(self.peek()) {
                 Some(_) => return Err(self.peek_error(ErrorCode::InvalidNumber)),
                 None => return Err(self.peek_error(ErrorCode::EofWhileParsingValue)),
             }
         }
 
+        let exponent = exponent_before_decimal_point + exponent_after_decimal_point;
         match tri!(self.peek_or_null()) {
             b'e' | b'E' => self.parse_exponent(positive, significand, exponent),
             _ => self.f64_from_parts(positive, significand, exponent),
@@ -946,6 +951,15 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             buf.push('-');
         }
         self.scan_integer(&mut buf)?;
+        if positive {
+            if let Ok(unsigned) = buf.parse() {
+                return Ok(ParserNumber::U64(unsigned));
+            }
+        } else {
+            if let Ok(signed) = buf.parse() {
+                return Ok(ParserNumber::I64(signed));
+            }
+        }
         Ok(ParserNumber::String(buf))
     }
 
@@ -1510,67 +1524,65 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         val
     }
 
-    serde_if_integer128! {
-        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: de::Visitor<'de>,
-        {
-            let mut buf = String::new();
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        let mut buf = String::new();
 
-            match tri!(self.parse_whitespace()) {
-                Some(b'-') => {
-                    self.eat_char();
-                    buf.push('-');
-                }
-                Some(_) => {}
-                None => {
-                    return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-                }
-            };
+        match tri!(self.parse_whitespace()) {
+            Some(b'-') => {
+                self.eat_char();
+                buf.push('-');
+            }
+            Some(_) => {}
+            None => {
+                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
+            }
+        };
 
-            tri!(self.scan_integer128(&mut buf));
+        tri!(self.scan_integer128(&mut buf));
 
-            let value = match buf.parse() {
-                Ok(int) => visitor.visit_i128(int),
-                Err(_) => {
-                    return Err(self.error(ErrorCode::NumberOutOfRange));
-                }
-            };
+        let value = match buf.parse() {
+            Ok(int) => visitor.visit_i128(int),
+            Err(_) => {
+                return Err(self.error(ErrorCode::NumberOutOfRange));
+            }
+        };
 
-            match value {
-                Ok(value) => Ok(value),
-                Err(err) => Err(self.fix_position(err)),
+        match value {
+            Ok(value) => Ok(value),
+            Err(err) => Err(self.fix_position(err)),
+        }
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        match tri!(self.parse_whitespace()) {
+            Some(b'-') => {
+                return Err(self.peek_error(ErrorCode::NumberOutOfRange));
+            }
+            Some(_) => {}
+            None => {
+                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
             }
         }
 
-        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: de::Visitor<'de>,
-        {
-            match tri!(self.parse_whitespace()) {
-                Some(b'-') => {
-                    return Err(self.peek_error(ErrorCode::NumberOutOfRange));
-                }
-                Some(_) => {}
-                None => {
-                    return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-                }
+        let mut buf = String::new();
+        tri!(self.scan_integer128(&mut buf));
+
+        let value = match buf.parse() {
+            Ok(int) => visitor.visit_u128(int),
+            Err(_) => {
+                return Err(self.error(ErrorCode::NumberOutOfRange));
             }
+        };
 
-            let mut buf = String::new();
-            tri!(self.scan_integer128(&mut buf));
-
-            let value = match buf.parse() {
-                Ok(int) => visitor.visit_u128(int),
-                Err(_) => {
-                    return Err(self.error(ErrorCode::NumberOutOfRange));
-                }
-            };
-
-            match value {
-                Ok(value) => Ok(value),
-                Err(err) => Err(self.fix_position(err)),
-            }
+        match value {
+            Ok(value) => Ok(value),
+            Err(err) => Err(self.fix_position(err)),
         }
     }
 
@@ -1650,7 +1662,8 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     ///
     /// # Examples
     ///
-    /// You can use this to parse JSON strings containing invalid UTF-8 bytes.
+    /// You can use this to parse JSON strings containing invalid UTF-8 bytes,
+    /// or unpaired surrogates.
     ///
     /// ```
     /// use serde_bytes::ByteBuf;
@@ -1670,20 +1683,18 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     /// ```
     ///
     /// Backslash escape sequences like `\n` are still interpreted and required
-    /// to be valid, and `\u` escape sequences are required to represent valid
-    /// Unicode code points.
+    /// to be valid. `\u` escape sequences are required to represent a valid
+    /// Unicode code point or lone surrogate.
     ///
     /// ```
     /// use serde_bytes::ByteBuf;
     ///
-    /// fn look_at_bytes() {
-    ///     let json_data = b"\"invalid unicode surrogate: \\uD801\"";
-    ///     let parsed: Result<ByteBuf, _> = serde_json_lenient::from_slice(json_data);
-    ///
-    ///     assert!(parsed.is_err());
-    ///
-    ///     let expected_msg = "unexpected end of hex escape at line 1 column 34";
-    ///     assert_eq!(expected_msg, parsed.unwrap_err().to_string());
+    /// fn look_at_bytes() -> Result<(), serde_json_lenient::Error> {
+    ///     let json_data = b"\"lone surrogate: \\uD801\"";
+    ///     let bytes: ByteBuf = serde_json_lenient::from_slice(json_data)?;
+    ///     let expected = b"lone surrogate: \xED\xA0\x81";
+    ///     assert_eq!(expected, bytes.as_slice());
+    ///     Ok(())
     /// }
     /// #
     /// # look_at_bytes();
@@ -2295,15 +2306,12 @@ where
     deserialize_integer_key!(deserialize_i16 => visit_i16);
     deserialize_integer_key!(deserialize_i32 => visit_i32);
     deserialize_integer_key!(deserialize_i64 => visit_i64);
+    deserialize_integer_key!(deserialize_i128 => visit_i128);
     deserialize_integer_key!(deserialize_u8 => visit_u8);
     deserialize_integer_key!(deserialize_u16 => visit_u16);
     deserialize_integer_key!(deserialize_u32 => visit_u32);
     deserialize_integer_key!(deserialize_u64 => visit_u64);
-
-    serde_if_integer128! {
-        deserialize_integer_key!(deserialize_i128 => visit_i128);
-        deserialize_integer_key!(deserialize_u128 => visit_u128);
-    }
+    deserialize_integer_key!(deserialize_u128 => visit_u128);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
@@ -2315,10 +2323,18 @@ where
     }
 
     #[inline]
-    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
+        #[cfg(feature = "raw_value")]
+        {
+            if name == crate::raw::TOKEN {
+                return self.de.deserialize_raw_value(visitor);
+            }
+        }
+
+        let _ = name;
         visitor.visit_newtype_struct(self)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,14 @@
 //! When serializing or deserializing JSON goes wrong.
 
 use crate::io;
-use crate::lib::str::FromStr;
-use crate::lib::*;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use core::fmt::{self, Debug, Display};
+use core::result;
+use core::str::FromStr;
 use serde::{de, ser};
+#[cfg(feature = "std")]
+use std::error;
 
 /// This type represents all possible errors that can occur when serializing or
 /// deserializing JSON data.
@@ -288,9 +293,9 @@ impl Error {
 
 impl Display for ErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ErrorCode::Message(ref msg) => f.write_str(msg),
-            ErrorCode::Io(ref err) => Display::fmt(err, f),
+        match self {
+            ErrorCode::Message(msg) => f.write_str(msg),
+            ErrorCode::Io(err) => Display::fmt(err, f),
             ErrorCode::EofWhileParsingBlockComment => {
                 f.write_str("EOF while parsing a block comment")
             }
@@ -326,8 +331,8 @@ impl Display for ErrorCode {
 impl serde::de::StdError for Error {
     #[cfg(feature = "std")]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self.err.code {
-            ErrorCode::Io(ref err) => Some(err),
+        match &self.err.code {
+            ErrorCode::Io(err) => err.source(),
             _ => None,
         }
     }
@@ -446,7 +451,7 @@ fn parse_line_col(msg: &mut String) -> Option<(usize, usize)> {
 }
 
 fn starts_with_digit(slice: &str) -> bool {
-    match slice.as_bytes().get(0) {
+    match slice.as_bytes().first() {
         None => false,
         Some(&byte) => byte >= b'0' && byte <= b'9',
     }

--- a/src/io/core.rs
+++ b/src/io/core.rs
@@ -1,7 +1,9 @@
 //! Reimplements core logic and types from `std::io` in an `alloc`-friendly
 //! fashion.
 
-use crate::lib::*;
+use alloc::vec::Vec;
+use core::fmt::{self, Display};
+use core::result;
 
 pub enum ErrorKind {
     Other,

--- a/src/lexical/bhcomp.rs
+++ b/src/lexical/bhcomp.rs
@@ -12,7 +12,7 @@ use super::float::*;
 use super::math::*;
 use super::num::*;
 use super::rounding::*;
-use crate::lib::{cmp, mem};
+use core::{cmp, mem};
 
 // MANTISSA
 

--- a/src/lexical/bignum.rs
+++ b/src/lexical/bignum.rs
@@ -3,7 +3,7 @@
 //! Big integer type definition.
 
 use super::math::*;
-use crate::lib::Vec;
+use alloc::vec::Vec;
 
 /// Storage for a big integer type.
 #[derive(Clone, PartialEq, Eq)]

--- a/src/lexical/math.rs
+++ b/src/lexical/math.rs
@@ -9,7 +9,8 @@
 use super::large_powers;
 use super::num::*;
 use super::small_powers::*;
-use crate::lib::{cmp, iter, mem, Vec};
+use alloc::vec::Vec;
+use core::{cmp, iter, mem};
 
 // ALIASES
 // -------
@@ -593,7 +594,7 @@ mod large {
 
         // Iteratively add elements from y to x.
         let mut carry = false;
-        for (xi, yi) in (&mut x[xstart..]).iter_mut().zip(y.iter()) {
+        for (xi, yi) in x[xstart..].iter_mut().zip(y.iter()) {
             // Only one op of the two can overflow, since we added at max
             // Limb::max_value() + Limb::max_value(). Add the previous carry,
             // and store the current carry for the next.

--- a/src/lexical/num.rs
+++ b/src/lexical/num.rs
@@ -2,7 +2,7 @@
 
 //! Utilities for Rust numbers.
 
-use crate::lib::ops;
+use core::ops;
 
 /// Precalculated values of radix**i for i in range [0, arr.len()-1].
 /// Each value can be **exactly** represented as that type.

--- a/src/lexical/rounding.rs
+++ b/src/lexical/rounding.rs
@@ -5,7 +5,7 @@
 use super::float::ExtendedFloat;
 use super::num::*;
 use super::shift::*;
-use crate::lib::mem;
+use core::mem;
 
 // MASKS
 

--- a/src/lexical/shift.rs
+++ b/src/lexical/shift.rs
@@ -3,7 +3,7 @@
 //! Bit-shift helpers.
 
 use super::float::ExtendedFloat;
-use crate::lib::mem;
+use core::mem;
 
 // Shift extended-precision float right `shift` bytes.
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@
 //! a JSON string to a Rust string with [`as_str()`] or avoiding the use of
 //! `Value` as described in the following section.
 //!
-//! [`as_str()`]: https://docs.serde.rs/serde_json_lenient/enum.Value.html#method.as_str
+//! [`as_str()`]: crate::Value::as_str
 //!
 //! The `Value` representation is sufficient for very basic tasks but can be
 //! tedious to work with for anything more significant. Error handling is
@@ -236,10 +236,10 @@
 //! });
 //! ```
 //!
-//! This is amazingly convenient but we have the problem we had before with
-//! `Value` which is that the IDE and Rust compiler cannot help us if we get it
-//! wrong. Serde jsonrc provides a better way of serializing strongly-typed data
-//! structures into JSON text.
+//! This is amazingly convenient, but we have the problem we had before with
+//! `Value`: the IDE and Rust compiler cannot help us if we get it wrong. Serde
+//! JSON provides a better way of serializing strongly-typed data structures
+//! into JSON text.
 //!
 //! # Creating JSON by serializing data structures
 //!
@@ -288,8 +288,8 @@
 //! # No-std support
 //!
 //! As long as there is a memory allocator, it is possible to use serde_json
-//! without the rest of the Rust standard library. This is supported on Rust
-//! 1.36+. Disable the default "std" feature and enable the "alloc" feature:
+//! without the rest of the Rust standard library. Disable the default "std"
+//! feature and enable the "alloc" feature:
 //!
 //! ```toml
 //! [dependencies]
@@ -299,28 +299,34 @@
 //! For JSON support in Serde without a memory allocator, please see the
 //! [`serde-json-core`] crate.
 //!
-//! [value]: https://docs.serde.rs/serde_json_lenient/value/enum.Value.html
-//! [from_str]: https://docs.serde.rs/serde_json_lenient/de/fn.from_str.html
-//! [from_slice]: https://docs.serde.rs/serde_json_lenient/de/fn.from_slice.html
-//! [from_reader]: https://docs.serde.rs/serde_json_lenient/de/fn.from_reader.html
-//! [to_string]: https://docs.serde.rs/serde_json_lenient/ser/fn.to_string.html
-//! [to_vec]: https://docs.serde.rs/serde_json_lenient/ser/fn.to_vec.html
-//! [to_writer]: https://docs.serde.rs/serde_json_lenient/ser/fn.to_writer.html
-//! [macro]: https://docs.serde.rs/serde_json_lenient/macro.json.html
+//! [value]: crate::value::Value
+//! [from_str]: crate::de::from_str
+//! [from_slice]: crate::de::from_slice
+//! [from_reader]: crate::de::from_reader
+//! [to_string]: crate::ser::to_string
+//! [to_vec]: crate::ser::to_vec
+//! [to_writer]: crate::ser::to_writer
+//! [macro]: crate::json
 //! [`serde-json-core`]: https://github.com/rust-embedded-community/serde-json-core
 
 #![doc(html_root_url = "https://docs.rs/serde_json_lenient/0.1.4")]
 // Ignored clippy lints
 #![allow(
+    clippy::collapsible_else_if,
     clippy::comparison_chain,
     clippy::deprecated_cfg_attr,
     clippy::doc_markdown,
     clippy::excessive_precision,
+    clippy::explicit_auto_deref,
     clippy::float_cmp,
     clippy::manual_range_contains,
     clippy::match_like_matches_macro,
     clippy::match_single_binding,
     clippy::needless_doctest_main,
+    clippy::needless_late_init,
+    // clippy bug: https://github.com/rust-lang/rust-clippy/issues/8366
+    clippy::ptr_arg,
+    clippy::return_self_not_must_use,
     clippy::transmute_ptr_to_ptr,
     clippy::unnecessary_wraps,
     // clippy bug: https://github.com/rust-lang/rust-clippy/issues/5704
@@ -328,6 +334,8 @@
 )]
 // Ignored clippy_pedantic lints
 #![allow(
+    // buggy
+    clippy::iter_not_returning_iterator, // https://github.com/rust-lang/rust-clippy/issues/8285
     // Deserializer::from_str, into_iter
     clippy::should_implement_trait,
     // integer and float ser/de requires these sorts of casts
@@ -339,6 +347,7 @@
     clippy::enum_glob_use,
     clippy::if_not_else,
     clippy::integer_division,
+    clippy::let_underscore_untyped,
     clippy::map_err_ignore,
     clippy::match_same_arms,
     clippy::similar_names,
@@ -367,64 +376,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-////////////////////////////////////////////////////////////////////////////////
-
-#[cfg(not(feature = "std"))]
 extern crate alloc;
-
-/// A facade around all the types we need from the `std`, `core`, and `alloc`
-/// crates. This avoids elaborate import wrangling having to happen in every
-/// module.
-mod lib {
-    mod core {
-        #[cfg(not(feature = "std"))]
-        pub use core::*;
-        #[cfg(feature = "std")]
-        pub use std::*;
-    }
-
-    pub use self::core::cell::{Cell, RefCell};
-    pub use self::core::clone::{self, Clone};
-    pub use self::core::convert::{self, From, Into};
-    pub use self::core::default::{self, Default};
-    pub use self::core::fmt::{self, Debug, Display};
-    pub use self::core::hash::{self, Hash, Hasher};
-    pub use self::core::iter::FusedIterator;
-    pub use self::core::marker::{self, PhantomData};
-    pub use self::core::ops::{Bound, RangeBounds};
-    pub use self::core::result::{self, Result};
-    pub use self::core::{borrow, char, cmp, iter, mem, num, ops, slice, str};
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::borrow::{Cow, ToOwned};
-    #[cfg(feature = "std")]
-    pub use std::borrow::{Cow, ToOwned};
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::string::{String, ToString};
-    #[cfg(feature = "std")]
-    pub use std::string::{String, ToString};
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::vec::{self, Vec};
-    #[cfg(feature = "std")]
-    pub use std::vec::{self, Vec};
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::boxed::Box;
-    #[cfg(feature = "std")]
-    pub use std::boxed::Box;
-
-    #[cfg(not(feature = "std"))]
-    pub use alloc::collections::{btree_map, BTreeMap};
-    #[cfg(feature = "std")]
-    pub use std::collections::{btree_map, BTreeMap};
-
-    #[cfg(feature = "std")]
-    pub use std::error;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 
 #[cfg(feature = "std")]
 #[doc(inline)]
@@ -444,14 +396,11 @@ pub use crate::value::{from_value, to_value, Map, Number, Value};
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
 macro_rules! tri {
-    ($e:expr) => {
+    ($e:expr $(,)?) => {
         match $e {
-            crate::lib::Result::Ok(val) => val,
-            crate::lib::Result::Err(err) => return crate::lib::Result::Err(err),
+            core::result::Result::Ok(val) => val,
+            core::result::Result::Err(err) => return core::result::Result::Err(err),
         }
-    };
-    ($e:expr,) => {
-        tri!($e)
     };
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,12 +6,19 @@
 //! [`BTreeMap`]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
 //! [`IndexMap`]: https://docs.rs/indexmap/*/indexmap/map/struct.IndexMap.html
 
-use crate::lib::borrow::Borrow;
-use crate::lib::iter::FromIterator;
-use crate::lib::*;
 use crate::value::Value;
+use alloc::string::String;
+use core::borrow::Borrow;
+use core::fmt::{self, Debug};
+use core::hash::Hash;
+use core::iter::{FromIterator, FusedIterator};
+#[cfg(feature = "preserve_order")]
+use core::mem;
+use core::ops;
 use serde::de;
 
+#[cfg(not(feature = "preserve_order"))]
+use alloc::collections::{btree_map, BTreeMap};
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
 
@@ -94,6 +101,20 @@ impl Map<String, Value> {
         self.map.get_mut(key)
     }
 
+    /// Returns the key-value pair matching the given key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but the ordering
+    /// on the borrowed form *must* match the ordering on the key type.
+    #[inline]
+    #[cfg(any(feature = "preserve_order", not(no_btreemap_get_key_value)))]
+    pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&String, &Value)>
+    where
+        String: Borrow<Q>,
+        Q: ?Sized + Ord + Eq + Hash,
+    {
+        self.map.get_key_value(key)
+    }
+
     /// Inserts a key-value pair into the map.
     ///
     /// If the map did not have this key present, `None` is returned.
@@ -151,6 +172,8 @@ impl Map<String, Value> {
             no_btreemap_get_key_value,
         ))]
         {
+            use core::ops::{Bound, RangeBounds};
+
             struct Key<'a, Q: ?Sized>(&'a Q);
 
             impl<'a, Q: ?Sized> RangeBounds<Q> for Key<'a, Q> {
@@ -170,13 +193,12 @@ impl Map<String, Value> {
         }
     }
 
-    /// Moves all elements from other into Self, leaving other empty.
+    /// Moves all elements from other into self, leaving other empty.
     #[inline]
     pub fn append(&mut self, other: &mut Self) {
         #[cfg(feature = "preserve_order")]
-        for (k, v) in mem::replace(&mut other.map, MapImpl::default()) {
-            self.map.insert(k, v);
-        }
+        self.map
+            .extend(mem::replace(&mut other.map, MapImpl::default()));
         #[cfg(not(feature = "preserve_order"))]
         self.map.append(&mut other.map);
     }
@@ -188,7 +210,7 @@ impl Map<String, Value> {
         S: Into<String>,
     {
         #[cfg(not(feature = "preserve_order"))]
-        use crate::lib::btree_map::Entry as EntryImpl;
+        use alloc::collections::btree_map::Entry as EntryImpl;
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
 
@@ -249,6 +271,19 @@ impl Map<String, Value> {
             iter: self.map.values_mut(),
         }
     }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)`
+    /// returns `false`.
+    #[cfg(not(no_btreemap_retain))]
+    #[inline]
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&String, &mut Value) -> bool,
+    {
+        self.map.retain(f);
+    }
 }
 
 #[allow(clippy::derivable_impls)] // clippy bug: https://github.com/rust-lang/rust-clippy/issues/7655
@@ -267,6 +302,11 @@ impl Clone for Map<String, Value> {
         Map {
             map: self.map.clone(),
         }
+    }
+
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        self.map.clone_from(&source.map);
     }
 }
 
@@ -287,10 +327,10 @@ impl Eq for Map<String, Value> {}
 /// #
 /// # let val = &Value::String("".to_owned());
 /// # let _ =
-/// match *val {
-///     Value::String(ref s) => Some(s.as_str()),
-///     Value::Array(ref arr) => arr[0].as_str(),
-///     Value::Object(ref map) => map["type"].as_str(),
+/// match val {
+///     Value::String(s) => Some(s.as_str()),
+///     Value::Array(arr) => arr[0].as_str(),
+///     Value::Object(map) => map["type"].as_str(),
 ///     _ => None,
 /// }
 /// # ;
@@ -494,9 +534,9 @@ impl<'a> Entry<'a> {
     /// assert_eq!(map.entry("serde").key(), &"serde");
     /// ```
     pub fn key(&self) -> &String {
-        match *self {
-            Entry::Vacant(ref e) => e.key(),
-            Entry::Occupied(ref e) => e.key(),
+        match self {
+            Entry::Vacant(e) => e.key(),
+            Entry::Occupied(e) => e.key(),
         }
     }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,16 +1,18 @@
 use crate::de::ParserNumber;
 use crate::error::Error;
-use crate::lib::*;
-use serde::de::{self, Unexpected, Visitor};
-use serde::{
-    forward_to_deserialize_any, serde_if_integer128, Deserialize, Deserializer, Serialize,
-    Serializer,
-};
-
 #[cfg(feature = "arbitrary_precision")]
 use crate::error::ErrorCode;
 #[cfg(feature = "arbitrary_precision")]
+use alloc::borrow::ToOwned;
+#[cfg(feature = "arbitrary_precision")]
+use alloc::string::{String, ToString};
+use core::fmt::{self, Debug, Display};
+#[cfg(not(feature = "arbitrary_precision"))]
+use core::hash::{Hash, Hasher};
+use serde::de::{self, Unexpected, Visitor};
+#[cfg(feature = "arbitrary_precision")]
 use serde::de::{IntoDeserializer, MapAccess};
+use serde::{forward_to_deserialize_any, Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "arbitrary_precision")]
 pub(crate) const TOKEN: &str = "$serde_json_lenient::private::Number";
@@ -277,6 +279,35 @@ impl Number {
         }
     }
 
+    pub(crate) fn as_f32(&self) -> Option<f32> {
+        #[cfg(not(feature = "arbitrary_precision"))]
+        match self.n {
+            N::PosInt(n) => Some(n as f32),
+            N::NegInt(n) => Some(n as f32),
+            N::Float(n) => Some(n as f32),
+        }
+        #[cfg(feature = "arbitrary_precision")]
+        self.n.parse::<f32>().ok().filter(|float| float.is_finite())
+    }
+
+    pub(crate) fn from_f32(f: f32) -> Option<Number> {
+        if f.is_finite() {
+            let n = {
+                #[cfg(not(feature = "arbitrary_precision"))]
+                {
+                    N::Float(f as f64)
+                }
+                #[cfg(feature = "arbitrary_precision")]
+                {
+                    ryu::Buffer::new().format_finite(f).to_owned()
+                }
+            };
+            Some(Number { n })
+        } else {
+            None
+        }
+    }
+
     #[cfg(feature = "arbitrary_precision")]
     /// Not public API. Only tests use this.
     #[doc(hidden)]
@@ -286,13 +317,13 @@ impl Number {
     }
 }
 
-impl fmt::Display for Number {
+impl Display for Number {
     #[cfg(not(feature = "arbitrary_precision"))]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self.n {
-            N::PosInt(u) => Display::fmt(&u, formatter),
-            N::NegInt(i) => Display::fmt(&i, formatter),
-            N::Float(f) => Display::fmt(&f, formatter),
+            N::PosInt(u) => formatter.write_str(itoa::Buffer::new().format(u)),
+            N::NegInt(i) => formatter.write_str(itoa::Buffer::new().format(i)),
+            N::Float(f) => formatter.write_str(ryu::Buffer::new().format_finite(f)),
         }
     }
 
@@ -303,29 +334,8 @@ impl fmt::Display for Number {
 }
 
 impl Debug for Number {
-    #[cfg(not(feature = "arbitrary_precision"))]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let mut debug = formatter.debug_tuple("Number");
-        match self.n {
-            N::PosInt(i) => {
-                debug.field(&i);
-            }
-            N::NegInt(i) => {
-                debug.field(&i);
-            }
-            N::Float(f) => {
-                debug.field(&f);
-            }
-        }
-        debug.finish()
-    }
-
-    #[cfg(feature = "arbitrary_precision")]
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter
-            .debug_tuple("Number")
-            .field(&format_args!("{}", self.n))
-            .finish()
+        write!(formatter, "Number({})", self)
     }
 }
 
@@ -556,17 +566,14 @@ impl<'de> Deserializer<'de> for Number {
     deserialize_number!(deserialize_i16 => visit_i16);
     deserialize_number!(deserialize_i32 => visit_i32);
     deserialize_number!(deserialize_i64 => visit_i64);
+    deserialize_number!(deserialize_i128 => visit_i128);
     deserialize_number!(deserialize_u8 => visit_u8);
     deserialize_number!(deserialize_u16 => visit_u16);
     deserialize_number!(deserialize_u32 => visit_u32);
     deserialize_number!(deserialize_u64 => visit_u64);
+    deserialize_number!(deserialize_u128 => visit_u128);
     deserialize_number!(deserialize_f32 => visit_f32);
     deserialize_number!(deserialize_f64 => visit_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128 => visit_i128);
-        deserialize_number!(deserialize_u128 => visit_u128);
-    }
 
     forward_to_deserialize_any! {
         bool char str string bytes byte_buf option unit unit_struct
@@ -584,17 +591,14 @@ impl<'de, 'a> Deserializer<'de> for &'a Number {
     deserialize_number!(deserialize_i16 => visit_i16);
     deserialize_number!(deserialize_i32 => visit_i32);
     deserialize_number!(deserialize_i64 => visit_i64);
+    deserialize_number!(deserialize_i128 => visit_i128);
     deserialize_number!(deserialize_u8 => visit_u8);
     deserialize_number!(deserialize_u16 => visit_u16);
     deserialize_number!(deserialize_u32 => visit_u32);
     deserialize_number!(deserialize_u64 => visit_u64);
+    deserialize_number!(deserialize_u128 => visit_u128);
     deserialize_number!(deserialize_f32 => visit_f32);
     deserialize_number!(deserialize_f64 => visit_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128 => visit_i128);
-        deserialize_number!(deserialize_u128 => visit_u128);
-    }
 
     forward_to_deserialize_any! {
         bool char str string bytes byte_buf option unit unit_struct
@@ -747,19 +751,9 @@ impl_from_unsigned!(u8, u16, u32, u64, usize);
 impl_from_signed!(i8, i16, i32, i64, isize);
 
 #[cfg(feature = "arbitrary_precision")]
-serde_if_integer128! {
-    impl From<i128> for Number {
-        fn from(i: i128) -> Self {
-            Number { n: i.to_string() }
-        }
-    }
-
-    impl From<u128> for Number {
-        fn from(u: u128) -> Self {
-            Number { n: u.to_string() }
-        }
-    }
-}
+impl_from_unsigned!(u128);
+#[cfg(feature = "arbitrary_precision")]
+impl_from_signed!(i128);
 
 impl Number {
     #[cfg(not(feature = "arbitrary_precision"))]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,5 +1,9 @@
 use crate::error::Error;
-use crate::lib::*;
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::fmt::{self, Debug, Display};
+use core::mem;
 use serde::de::value::BorrowedStrDeserializer;
 use serde::de::{
     self, Deserialize, DeserializeSeed, Deserializer, IntoDeserializer, MapAccess, Unexpected,
@@ -108,7 +112,7 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 ///     raw_value: Box<RawValue>,
 /// }
 /// ```
-#[repr(C)]
+#[cfg_attr(not(doc), repr(transparent))]
 #[cfg_attr(docsrs, doc(cfg(feature = "raw_value")))]
 pub struct RawValue {
     json: str,
@@ -121,6 +125,10 @@ impl RawValue {
 
     fn from_owned(json: Box<str>) -> Box<Self> {
         unsafe { mem::transmute::<Box<str>, Box<RawValue>>(json) }
+    }
+
+    fn into_owned(raw_value: Box<Self>) -> Box<str> {
+        unsafe { mem::transmute::<Box<RawValue>, Box<str>>(raw_value) }
     }
 }
 
@@ -216,6 +224,12 @@ impl RawValue {
     }
 }
 
+impl From<Box<RawValue>> for Box<str> {
+    fn from(raw_value: Box<RawValue>) -> Self {
+        RawValue::into_owned(raw_value)
+    }
+}
+
 /// Convert a `T` into a boxed `RawValue`.
 ///
 /// # Example
@@ -271,7 +285,7 @@ impl RawValue {
 #[cfg_attr(docsrs, doc(cfg(feature = "raw_value")))]
 pub fn to_raw_value<T>(value: &T) -> Result<Box<RawValue>, Error>
 where
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     let json_string = crate::to_string(value)?;
     Ok(RawValue::from_owned(json_string.into_boxed_str()))
@@ -435,9 +449,10 @@ impl<'de> Visitor<'de> for BoxedFromString {
     where
         E: de::Error,
     {
-        self.visit_string(s.to_owned())
+        Ok(RawValue::from_owned(s.to_owned().into_boxed_str()))
     }
 
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
     where
         E: de::Error,

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,6 +1,9 @@
 use crate::error::{Error, ErrorCode, Result};
-use crate::lib::ops::Deref;
-use crate::lib::*;
+use alloc::vec::Vec;
+use core::char;
+use core::cmp;
+use core::ops::Deref;
+use core::str;
 
 #[cfg(feature = "std")]
 use crate::io;
@@ -389,7 +392,7 @@ where
                     return utf_strategy.to_result_simple(self, scratch);
                 }
                 b'\\' => {
-                    tri!(parse_escape(self, scratch));
+                    tri!(parse_escape(self, validate, scratch));
                 }
                 _ => {
                     if validate {
@@ -425,7 +428,7 @@ where
             Some(ch) => {
                 #[cfg(feature = "raw_value")]
                 {
-                    if let Some(ref mut buf) = self.raw_buffer {
+                    if let Some(buf) = &mut self.raw_buffer {
                         buf.push(ch);
                     }
                 }
@@ -436,7 +439,7 @@ where
                 Some(Ok(ch)) => {
                     #[cfg(feature = "raw_value")]
                     {
-                        if let Some(ref mut buf) = self.raw_buffer {
+                        if let Some(buf) = &mut self.raw_buffer {
                             buf.push(ch);
                         }
                     }
@@ -471,7 +474,7 @@ where
     #[cfg(feature = "raw_value")]
     fn discard(&mut self) {
         if let Some(ch) = self.ch.take() {
-            if let Some(ref mut buf) = self.raw_buffer {
+            if let Some(buf) = &mut self.raw_buffer {
                 buf.push(ch);
             }
         }
@@ -651,7 +654,7 @@ impl<'a> SliceRead<'a> {
                 b'\\' => {
                     utf_strategy.extend_scratch(scratch, &self.slice[start..self.index]);
                     self.index += 1;
-                    tri!(parse_escape(self, scratch));
+                    tri!(parse_escape(self, validate, scratch));
                     start = self.index;
                 }
                 _ => {
@@ -1042,17 +1045,12 @@ where
     }
 }
 
-fn next_expecting<'de, R: ?Sized + Read<'de>>(
-    read: &mut R,
-    expected: u8,
-    errcode: ErrorCode,
-) -> Result<u8> {
+fn peek_or_eof<'de, R>(read: &mut R) -> Result<u8>
+where
+    R: ?Sized + Read<'de>,
+{
     match tri!(read.peek()) {
-        Some(b) if b == expected => {
-            read.discard();
-            Ok(b)
-        }
-        Some(_) => error(read, errcode),
+        Some(b) => Ok(b),
         None => error(read, ErrorCode::EofWhileParsingString),
     }
 }
@@ -1065,8 +1063,12 @@ where
     Err(Error::syntax(reason, position.line, position.column))
 }
 
-fn parse_escape<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) -> Result<()> {
-    let r = parse_escape_or_fail(read, scratch);
+fn parse_escape<'de, R: Read<'de>>(
+    read: &mut R,
+    validate: bool,
+    scratch: &mut Vec<u8>,
+) -> Result<()> {
+    let r = parse_escape_or_fail(read, validate, scratch);
     if read.replace_invalid_unicode() {
         match r {
             Ok(a) => Ok(a),
@@ -1082,7 +1084,11 @@ fn parse_escape<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) -> Resul
 
 /// Parses a JSON escape sequence and appends it into the scratch space. Assumes
 /// the previous byte read was a backslash.
-fn parse_escape_or_fail<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) -> Result<()> {
+fn parse_escape_or_fail<'de, R: Read<'de>>(
+    read: &mut R,
+    validate: bool,
+    scratch: &mut Vec<u8>,
+) -> Result<()> {
     let ch = tri!(next_or_eof(read));
 
     match ch {
@@ -1106,27 +1112,60 @@ fn parse_escape_or_fail<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) 
             scratch.extend_from_slice(c.encode_utf8(&mut [0_u8; 4]).as_bytes());
         }
         b'u' => {
+            fn encode_surrogate(scratch: &mut Vec<u8>, n: u16) {
+                scratch.extend_from_slice(&[
+                    (n >> 12 & 0b0000_1111) as u8 | 0b1110_0000,
+                    (n >> 6 & 0b0011_1111) as u8 | 0b1000_0000,
+                    (n & 0b0011_1111) as u8 | 0b1000_0000,
+                ]);
+            }
+
             let c = match tri!(read.decode_hex_escape(4)) {
-                0xDC00..=0xDFFF => {
-                    return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
+                n @ 0xDC00..=0xDFFF => {
+                    return if validate {
+                        error(read, ErrorCode::LoneLeadingSurrogateInHexEscape)
+                    } else {
+                        encode_surrogate(scratch, n);
+                        Ok(())
+                    };
                 }
                 // Optionally, refuse to decode Unicode non-characters.
                 0xFDD0..=0xFDEF => '\u{fffd}',
                 n if (n & 0xFFFE == 0xFFFE || n == 0xFFFF) => '\u{fffd}',
 
-                // Non-BMP characters are encoded as a sequence of
-                // two hex escapes, representing UTF-16 surrogates.
+                // Non-BMP characters are encoded as a sequence of two hex
+                // escapes, representing UTF-16 surrogates. If deserializing a
+                // utf-8 string the surrogates are required to be paired,
+                // whereas deserializing a byte string accepts lone surrogates.
                 n1 @ 0xD800..=0xDBFF => {
-                    tri!(next_expecting(
-                        read,
-                        b'\\',
-                        ErrorCode::UnexpectedEndOfHexEscape
-                    ));
-                    tri!(next_expecting(
-                        read,
-                        b'u',
-                        ErrorCode::UnexpectedEndOfHexEscape
-                    ));
+                    if tri!(peek_or_eof(read)) == b'\\' {
+                        read.discard();
+                    } else {
+                        return if validate {
+                            read.discard();
+                            error(read, ErrorCode::UnexpectedEndOfHexEscape)
+                        } else {
+                            encode_surrogate(scratch, n1);
+                            Ok(())
+                        };
+                    }
+
+                    if tri!(peek_or_eof(read)) == b'u' {
+                        read.discard();
+                    } else {
+                        return if validate {
+                            read.discard();
+                            error(read, ErrorCode::UnexpectedEndOfHexEscape)
+                        } else {
+                            encode_surrogate(scratch, n1);
+                            // The \ prior to this byte started an escape sequence,
+                            // so we need to parse that now. This recursive call
+                            // does not blow the stack on malicious input because
+                            // the escape is not \u, so it will be handled by one
+                            // of the easy nonrecursive cases.
+                            parse_escape(read, validate, scratch)
+                        };
+                    }
 
                     let n2 = tri!(read.decode_hex_escape(4));
 
@@ -1148,12 +1187,9 @@ fn parse_escape_or_fail<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) 
                     }
                 }
 
-                n => match char::from_u32(n as u32) {
-                    Some(c) => c,
-                    None => {
-                        return error(read, ErrorCode::InvalidUnicodeCodePoint);
-                    }
-                },
+                // Every u16 outside of the surrogate ranges above is guaranteed
+                // to be a legal char.
+                n => char::from_u32(n as u32).unwrap(),
             };
 
             scratch.extend_from_slice(c.encode_utf8(&mut [0_u8; 4]).as_bytes());
@@ -1177,36 +1213,13 @@ where
     match ch {
         b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' | b'v' => {}
         b'u' => {
-            let n = match tri!(read.decode_hex_escape(4)) {
-                0xDC00..=0xDFFF => {
-                    return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
-                }
+            // At this point we don't care if the codepoint is valid. We just
+            // want to consume it. We don't actually know what is valid or not
+            // at this point, because that depends on if this string will
+            // ultimately be parsed into a string or a byte buffer in the "real"
+            // parse.
 
-                // Non-BMP characters are encoded as a sequence of
-                // two hex escapes, representing UTF-16 surrogates.
-                n1 @ 0xD800..=0xDBFF => {
-                    if tri!(next_or_eof(read)) != b'\\' {
-                        return error(read, ErrorCode::UnexpectedEndOfHexEscape);
-                    }
-                    if tri!(next_or_eof(read)) != b'u' {
-                        return error(read, ErrorCode::UnexpectedEndOfHexEscape);
-                    }
-
-                    let n2 = tri!(read.decode_hex_escape(4));
-
-                    if n2 < 0xDC00 || n2 > 0xDFFF {
-                        return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
-                    }
-
-                    (((n1 - 0xD800) as u32) << 10 | (n2 - 0xDC00) as u32) + 0x1_0000
-                }
-
-                n => n as u32,
-            };
-
-            if char::from_u32(n).is_none() {
-                return error(read, ErrorCode::InvalidUnicodeCodePoint);
-            }
+            tri!(read.decode_hex_escape(4));
         }
         b'x' => {
             let c: u32 = tri!(read.decode_hex_escape(2)).into();

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2,10 +2,11 @@
 
 use crate::error::{Error, ErrorCode, Result};
 use crate::io;
-use crate::lib::num::FpCategory;
-use crate::lib::*;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt::{self, Display};
+use core::num::FpCategory;
 use serde::ser::{self, Impossible, Serialize};
-use serde::serde_if_integer128;
 
 /// A structure for serializing Rust values into JSON.
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -73,137 +74,105 @@ where
 
     #[inline]
     fn serialize_bool(self, value: bool) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_bool(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_i8(self, value: i8) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_i8(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_i16(self, value: i16) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_i16(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_i32(self, value: i32) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_i32(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_i64(self, value: i64) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_i64(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, value: i128) -> Result<()> {
-            self.formatter
-                .write_number_str(&mut self.writer, &value.to_string())
-                .map_err(Error::io)
-        }
+    fn serialize_i128(self, value: i128) -> Result<()> {
+        self.formatter
+            .write_i128(&mut self.writer, value)
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_u8(self, value: u8) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_u8(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_u16(self, value: u16) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_u16(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_u32(self, value: u32) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_u32(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_u64(self, value: u64) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_u64(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, value: u128) -> Result<()> {
-            self.formatter
-                .write_number_str(&mut self.writer, &value.to_string())
-                .map_err(Error::io)
-        }
+    fn serialize_u128(self, value: u128) -> Result<()> {
+        self.formatter
+            .write_u128(&mut self.writer, value)
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_f32(self, value: f32) -> Result<()> {
         match value.classify() {
-            FpCategory::Nan | FpCategory::Infinite => {
-                tri!(self
-                    .formatter
-                    .write_null(&mut self.writer)
-                    .map_err(Error::io));
-            }
-            _ => {
-                tri!(self
-                    .formatter
-                    .write_f32(&mut self.writer, value)
-                    .map_err(Error::io));
-            }
+            FpCategory::Nan | FpCategory::Infinite => self
+                .formatter
+                .write_null(&mut self.writer)
+                .map_err(Error::io),
+            _ => self
+                .formatter
+                .write_f32(&mut self.writer, value)
+                .map_err(Error::io),
         }
-        Ok(())
     }
 
     #[inline]
     fn serialize_f64(self, value: f64) -> Result<()> {
         match value.classify() {
-            FpCategory::Nan | FpCategory::Infinite => {
-                tri!(self
-                    .formatter
-                    .write_null(&mut self.writer)
-                    .map_err(Error::io));
-            }
-            _ => {
-                tri!(self
-                    .formatter
-                    .write_f64(&mut self.writer, value)
-                    .map_err(Error::io));
-            }
+            FpCategory::Nan | FpCategory::Infinite => self
+                .formatter
+                .write_null(&mut self.writer)
+                .map_err(Error::io),
+            _ => self
+                .formatter
+                .write_f64(&mut self.writer, value)
+                .map_err(Error::io),
         }
-        Ok(())
     }
 
     #[inline]
@@ -215,8 +184,7 @@ where
 
     #[inline]
     fn serialize_str(self, value: &str) -> Result<()> {
-        tri!(format_escaped_str(&mut self.writer, &mut self.formatter, value).map_err(Error::io));
-        Ok(())
+        format_escaped_str(&mut self.writer, &mut self.formatter, value).map_err(Error::io)
     }
 
     #[inline]
@@ -231,11 +199,9 @@ where
 
     #[inline]
     fn serialize_unit(self) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_null(&mut self.writer)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
@@ -295,11 +261,9 @@ where
             .formatter
             .end_object_value(&mut self.writer)
             .map_err(Error::io));
-        tri!(self
-            .formatter
+        self.formatter
             .end_object(&mut self.writer)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
@@ -488,11 +452,9 @@ where
                 }
             }
         }
-        tri!(self
-            .formatter
+        self.formatter
             .end_string(&mut self.writer)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 }
 
@@ -531,22 +493,17 @@ where
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            Compound::Map {
-                ref mut ser,
-                ref mut state,
-            } => {
+        match self {
+            Compound::Map { ser, state } => {
                 tri!(ser
                     .formatter
                     .begin_array_value(&mut ser.writer, *state == State::First)
                     .map_err(Error::io));
                 *state = State::Rest;
                 tri!(value.serialize(&mut **ser));
-                tri!(ser
-                    .formatter
+                ser.formatter
                     .end_array_value(&mut ser.writer)
-                    .map_err(Error::io));
-                Ok(())
+                    .map_err(Error::io)
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
@@ -558,13 +515,10 @@ where
     #[inline]
     fn end(self) -> Result<()> {
         match self {
-            Compound::Map { ser, state } => {
-                match state {
-                    State::Empty => {}
-                    _ => tri!(ser.formatter.end_array(&mut ser.writer).map_err(Error::io)),
-                }
-                Ok(())
-            }
+            Compound::Map { ser, state } => match state {
+                State::Empty => Ok(()),
+                _ => ser.formatter.end_array(&mut ser.writer).map_err(Error::io),
+            },
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
             #[cfg(feature = "raw_value")]
@@ -645,8 +599,7 @@ where
                     .formatter
                     .end_object_value(&mut ser.writer)
                     .map_err(Error::io));
-                tri!(ser.formatter.end_object(&mut ser.writer).map_err(Error::io));
-                Ok(())
+                ser.formatter.end_object(&mut ser.writer).map_err(Error::io)
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
@@ -669,11 +622,8 @@ where
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            Compound::Map {
-                ref mut ser,
-                ref mut state,
-            } => {
+        match self {
+            Compound::Map { ser, state } => {
                 tri!(ser
                     .formatter
                     .begin_object_key(&mut ser.writer, *state == State::First)
@@ -682,11 +632,9 @@ where
 
                 tri!(key.serialize(MapKeySerializer { ser: *ser }));
 
-                tri!(ser
-                    .formatter
+                ser.formatter
                     .end_object_key(&mut ser.writer)
-                    .map_err(Error::io));
-                Ok(())
+                    .map_err(Error::io)
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
@@ -700,18 +648,16 @@ where
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            Compound::Map { ref mut ser, .. } => {
+        match self {
+            Compound::Map { ser, .. } => {
                 tri!(ser
                     .formatter
                     .begin_object_value(&mut ser.writer)
                     .map_err(Error::io));
                 tri!(value.serialize(&mut **ser));
-                tri!(ser
-                    .formatter
+                ser.formatter
                     .end_object_value(&mut ser.writer)
-                    .map_err(Error::io));
-                Ok(())
+                    .map_err(Error::io)
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
@@ -723,13 +669,10 @@ where
     #[inline]
     fn end(self) -> Result<()> {
         match self {
-            Compound::Map { ser, state } => {
-                match state {
-                    State::Empty => {}
-                    _ => tri!(ser.formatter.end_object(&mut ser.writer).map_err(Error::io)),
-                }
-                Ok(())
-            }
+            Compound::Map { ser, state } => match state {
+                State::Empty => Ok(()),
+                _ => ser.formatter.end_object(&mut ser.writer).map_err(Error::io),
+            },
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
             #[cfg(feature = "raw_value")]
@@ -751,22 +694,20 @@ where
     where
         T: ?Sized + Serialize,
     {
-        match *self {
+        match self {
             Compound::Map { .. } => ser::SerializeMap::serialize_entry(self, key, value),
             #[cfg(feature = "arbitrary_precision")]
-            Compound::Number { ref mut ser, .. } => {
+            Compound::Number { ser, .. } => {
                 if key == crate::number::TOKEN {
-                    tri!(value.serialize(NumberStrEmitter(ser)));
-                    Ok(())
+                    value.serialize(NumberStrEmitter(ser))
                 } else {
                     Err(invalid_number())
                 }
             }
             #[cfg(feature = "raw_value")]
-            Compound::RawValue { ref mut ser, .. } => {
+            Compound::RawValue { ser, .. } => {
                 if key == crate::raw::TOKEN {
-                    tri!(value.serialize(RawValueStrEmitter(ser)));
-                    Ok(())
+                    value.serialize(RawValueStrEmitter(ser))
                 } else {
                     Err(invalid_raw_value())
                 }
@@ -820,8 +761,7 @@ where
                     .formatter
                     .end_object_value(&mut ser.writer)
                     .map_err(Error::io));
-                tri!(ser.formatter.end_object(&mut ser.writer).map_err(Error::io));
-                Ok(())
+                ser.formatter.end_object(&mut ser.writer).map_err(Error::io)
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
@@ -903,12 +843,10 @@ where
             .formatter
             .write_i8(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
+        self.ser
             .formatter
             .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     fn serialize_i16(self, value: i16) -> Result<()> {
@@ -922,12 +860,10 @@ where
             .formatter
             .write_i16(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
+        self.ser
             .formatter
             .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     fn serialize_i32(self, value: i32) -> Result<()> {
@@ -941,12 +877,10 @@ where
             .formatter
             .write_i32(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
+        self.ser
             .formatter
             .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     fn serialize_i64(self, value: i64) -> Result<()> {
@@ -960,33 +894,27 @@ where
             .formatter
             .write_i64(&mut self.ser.writer, value)
             .map_err(Error::io));
+        self.ser
+            .formatter
+            .end_string(&mut self.ser.writer)
+            .map_err(Error::io)
+    }
+
+    fn serialize_i128(self, value: i128) -> Result<()> {
         tri!(self
             .ser
             .formatter
-            .end_string(&mut self.ser.writer)
+            .begin_string(&mut self.ser.writer)
             .map_err(Error::io));
-        Ok(())
-    }
-
-    serde_if_integer128! {
-        fn serialize_i128(self, value: i128) -> Result<()> {
-            tri!(self
-                .ser
-                .formatter
-                .begin_string(&mut self.ser.writer)
-                .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .write_number_str(&mut self.ser.writer, &value.to_string())
-                .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .end_string(&mut self.ser.writer)
-                .map_err(Error::io));
-            Ok(())
-        }
+        tri!(self
+            .ser
+            .formatter
+            .write_i128(&mut self.ser.writer, value)
+            .map_err(Error::io));
+        self.ser
+            .formatter
+            .end_string(&mut self.ser.writer)
+            .map_err(Error::io)
     }
 
     fn serialize_u8(self, value: u8) -> Result<()> {
@@ -1000,12 +928,10 @@ where
             .formatter
             .write_u8(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
+        self.ser
             .formatter
             .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     fn serialize_u16(self, value: u16) -> Result<()> {
@@ -1019,12 +945,10 @@ where
             .formatter
             .write_u16(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
+        self.ser
             .formatter
             .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     fn serialize_u32(self, value: u32) -> Result<()> {
@@ -1038,12 +962,10 @@ where
             .formatter
             .write_u32(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
+        self.ser
             .formatter
             .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     fn serialize_u64(self, value: u64) -> Result<()> {
@@ -1057,33 +979,27 @@ where
             .formatter
             .write_u64(&mut self.ser.writer, value)
             .map_err(Error::io));
+        self.ser
+            .formatter
+            .end_string(&mut self.ser.writer)
+            .map_err(Error::io)
+    }
+
+    fn serialize_u128(self, value: u128) -> Result<()> {
         tri!(self
             .ser
             .formatter
-            .end_string(&mut self.ser.writer)
+            .begin_string(&mut self.ser.writer)
             .map_err(Error::io));
-        Ok(())
-    }
-
-    serde_if_integer128! {
-        fn serialize_u128(self, value: u128) -> Result<()> {
-            tri!(self
-                .ser
-                .formatter
-                .begin_string(&mut self.ser.writer)
-                .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .write_number_str(&mut self.ser.writer, &value.to_string())
-                .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .end_string(&mut self.ser.writer)
-                .map_err(Error::io));
-            Ok(())
-        }
+        tri!(self
+            .ser
+            .formatter
+            .write_u128(&mut self.ser.writer, value)
+            .map_err(Error::io));
+        self.ser
+            .formatter
+            .end_string(&mut self.ser.writer)
+            .map_err(Error::io)
     }
 
     fn serialize_f32(self, _value: f32) -> Result<()> {
@@ -1222,10 +1138,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
         Err(invalid_number())
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, _v: i128) -> Result<()> {
-            Err(invalid_number())
-        }
+    fn serialize_i128(self, _v: i128) -> Result<()> {
+        Err(invalid_number())
     }
 
     fn serialize_u8(self, _v: u8) -> Result<()> {
@@ -1244,10 +1158,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
         Err(invalid_number())
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, _v: u128) -> Result<()> {
-            Err(invalid_number())
-        }
+    fn serialize_u128(self, _v: u128) -> Result<()> {
+        Err(invalid_number())
     }
 
     fn serialize_f32(self, _v: f32) -> Result<()> {
@@ -1403,10 +1315,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         Err(ser::Error::custom("expected RawValue"))
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, _v: i128) -> Result<()> {
-            Err(ser::Error::custom("expected RawValue"))
-        }
+    fn serialize_i128(self, _v: i128) -> Result<()> {
+        Err(ser::Error::custom("expected RawValue"))
     }
 
     fn serialize_u8(self, _v: u8) -> Result<()> {
@@ -1425,10 +1335,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         Err(ser::Error::custom("expected RawValue"))
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, _v: u128) -> Result<()> {
-            Err(ser::Error::custom("expected RawValue"))
-        }
+    fn serialize_u128(self, _v: u128) -> Result<()> {
+        Err(ser::Error::custom("expected RawValue"))
     }
 
     fn serialize_f32(self, _v: f32) -> Result<()> {
@@ -1546,6 +1454,13 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
     ) -> Result<Self::SerializeStructVariant> {
         Err(ser::Error::custom("expected RawValue"))
     }
+
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Display,
+    {
+        self.serialize_str(&value.to_string())
+    }
 }
 
 /// Represents a character escape code in a type-safe manner.
@@ -1658,6 +1573,17 @@ pub trait Formatter {
         writer.write_all(s.as_bytes())
     }
 
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    fn write_i128<W>(&mut self, writer: &mut W, value: i128) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
+    }
+
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
     fn write_u8<W>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
@@ -1694,6 +1620,17 @@ pub trait Formatter {
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
     fn write_u64<W>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
+    }
+
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    fn write_u128<W>(&mut self, writer: &mut W, value: u128) -> io::Result<()>
     where
         W: ?Sized + io::Write,
     {
@@ -1982,13 +1919,8 @@ impl<'a> Formatter for PrettyFormatter<'a> {
     where
         W: ?Sized + io::Write,
     {
-        if first {
-            tri!(writer.write_all(b"\n"));
-        } else {
-            tri!(writer.write_all(b",\n"));
-        }
-        tri!(indent(writer, self.current_indent, self.indent));
-        Ok(())
+        tri!(writer.write_all(if first { b"\n" } else { b",\n" }));
+        indent(writer, self.current_indent, self.indent)
     }
 
     #[inline]
@@ -2030,11 +1962,7 @@ impl<'a> Formatter for PrettyFormatter<'a> {
     where
         W: ?Sized + io::Write,
     {
-        if first {
-            tri!(writer.write_all(b"\n"));
-        } else {
-            tri!(writer.write_all(b",\n"));
-        }
+        tri!(writer.write_all(if first { b"\n" } else { b",\n" }));
         indent(writer, self.current_indent, self.indent)
     }
 
@@ -2063,8 +1991,7 @@ where
 {
     tri!(formatter.begin_string(writer));
     tri!(format_escaped_str_contents(writer, formatter, value));
-    tri!(formatter.end_string(writer));
-    Ok(())
+    formatter.end_string(writer)
 }
 
 fn format_escaped_str_contents<W, F>(
@@ -2096,11 +2023,11 @@ where
         start = i + 1;
     }
 
-    if start != bytes.len() {
-        tri!(formatter.write_string_fragment(writer, &value[start..]));
+    if start == bytes.len() {
+        return Ok(());
     }
 
-    Ok(())
+    formatter.write_string_fragment(writer, &value[start..])
 }
 
 const BB: u8 = b'b'; // \x08
@@ -2137,6 +2064,8 @@ static ESCAPE: [u8; 256] = [
 
 /// Serialize the given data structure as JSON into the IO stream.
 ///
+/// Serialization guarantees it only feeds valid UTF-8 sequences to the writer.
+///
 /// # Errors
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
@@ -2149,12 +2078,13 @@ where
     T: ?Sized + Serialize,
 {
     let mut ser = Serializer::new(writer);
-    tri!(value.serialize(&mut ser));
-    Ok(())
+    value.serialize(&mut ser)
 }
 
 /// Serialize the given data structure as pretty-printed JSON into the IO
 /// stream.
+///
+/// Serialization guarantees it only feeds valid UTF-8 sequences to the writer.
 ///
 /// # Errors
 ///
@@ -2168,8 +2098,7 @@ where
     T: ?Sized + Serialize,
 {
     let mut ser = Serializer::pretty(writer);
-    tri!(value.serialize(&mut ser));
-    Ok(())
+    value.serialize(&mut ser)
 }
 
 /// Serialize the given data structure as a JSON byte vector.

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,14 +1,20 @@
 use crate::error::Error;
-use crate::lib::str::FromStr;
-use crate::lib::*;
 use crate::map::Map;
 use crate::number::Number;
 use crate::value::Value;
+use alloc::borrow::{Cow, ToOwned};
+use alloc::string::String;
+#[cfg(feature = "raw_value")]
+use alloc::string::ToString;
+use alloc::vec::{self, Vec};
+use core::fmt;
+use core::slice;
+use core::str::FromStr;
 use serde::de::{
     self, Deserialize, DeserializeSeed, EnumAccess, Expected, IntoDeserializer, MapAccess,
     SeqAccess, Unexpected, VariantAccess, Visitor,
 };
-use serde::{forward_to_deserialize_any, serde_if_integer128};
+use serde::forward_to_deserialize_any;
 
 #[cfg(feature = "arbitrary_precision")]
 use crate::number::NumberFromString;
@@ -222,17 +228,14 @@ impl<'de> serde::Deserializer<'de> for Value {
     deserialize_number!(deserialize_i16);
     deserialize_number!(deserialize_i32);
     deserialize_number!(deserialize_i64);
+    deserialize_number!(deserialize_i128);
     deserialize_number!(deserialize_u8);
     deserialize_number!(deserialize_u16);
     deserialize_number!(deserialize_u32);
     deserialize_number!(deserialize_u64);
+    deserialize_number!(deserialize_u128);
     deserialize_number!(deserialize_f32);
     deserialize_number!(deserialize_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128);
-        deserialize_number!(deserialize_u128);
-    }
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
@@ -642,8 +645,8 @@ macro_rules! deserialize_value_ref_number {
         where
             V: Visitor<'de>,
         {
-            match *self {
-                Value::Number(ref n) => n.deserialize_any(visitor),
+            match self {
+                Value::Number(n) => n.deserialize_any(visitor),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -653,8 +656,8 @@ macro_rules! deserialize_value_ref_number {
         where
             V: Visitor<'de>,
         {
-            match *self {
-                Value::Number(ref n) => n.$method(visitor),
+            match self {
+                Value::Number(n) => n.$method(visitor),
                 _ => self.deserialize_any(visitor),
             }
         }
@@ -704,13 +707,13 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
+        match self {
             Value::Null => visitor.visit_unit(),
-            Value::Bool(v) => visitor.visit_bool(v),
-            Value::Number(ref n) => n.deserialize_any(visitor),
-            Value::String(ref v) => visitor.visit_borrowed_str(v),
-            Value::Array(ref v) => visit_array_ref(v, visitor),
-            Value::Object(ref v) => visit_object_ref(v, visitor),
+            Value::Bool(v) => visitor.visit_bool(*v),
+            Value::Number(n) => n.deserialize_any(visitor),
+            Value::String(v) => visitor.visit_borrowed_str(v),
+            Value::Array(v) => visit_array_ref(v, visitor),
+            Value::Object(v) => visit_object_ref(v, visitor),
         }
     }
 
@@ -718,17 +721,14 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     deserialize_value_ref_number!(deserialize_i16);
     deserialize_value_ref_number!(deserialize_i32);
     deserialize_value_ref_number!(deserialize_i64);
+    deserialize_number!(deserialize_i128);
     deserialize_value_ref_number!(deserialize_u8);
     deserialize_value_ref_number!(deserialize_u16);
     deserialize_value_ref_number!(deserialize_u32);
     deserialize_value_ref_number!(deserialize_u64);
+    deserialize_number!(deserialize_u128);
     deserialize_value_ref_number!(deserialize_f32);
     deserialize_value_ref_number!(deserialize_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128);
-        deserialize_number!(deserialize_u128);
-    }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
     where
@@ -749,8 +749,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        let (variant, value) = match *self {
-            Value::Object(ref value) => {
+        let (variant, value) = match self {
+            Value::Object(value) => {
                 let mut iter = value.into_iter();
                 let (variant, value) = match iter.next() {
                     Some(v) => v,
@@ -770,8 +770,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
                 }
                 (variant, Some(value))
             }
-            Value::String(ref variant) => (variant, None),
-            ref other => {
+            Value::String(variant) => (variant, None),
+            other => {
                 return Err(serde::de::Error::invalid_type(
                     other.unexpected(),
                     &"string or map",
@@ -825,8 +825,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::String(ref v) => visitor.visit_borrowed_str(v),
+        match self {
+            Value::String(v) => visitor.visit_borrowed_str(v),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -842,9 +842,9 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::String(ref v) => visitor.visit_borrowed_str(v),
-            Value::Array(ref v) => visit_array_ref(v, visitor),
+        match self {
+            Value::String(v) => visitor.visit_borrowed_str(v),
+            Value::Array(v) => visit_array_ref(v, visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -877,8 +877,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::Array(ref v) => visit_array_ref(v, visitor),
+        match self {
+            Value::Array(v) => visit_array_ref(v, visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -906,8 +906,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::Object(ref v) => visit_object_ref(v, visitor),
+        match self {
+            Value::Object(v) => visit_object_ref(v, visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -921,9 +921,9 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::Array(ref v) => visit_array_ref(v, visitor),
-            Value::Object(ref v) => visit_object_ref(v, visitor),
+        match self {
+            Value::Array(v) => visit_array_ref(v, visitor),
+            Value::Object(v) => visit_object_ref(v, visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -994,7 +994,7 @@ impl<'de> VariantAccess<'de> for VariantRefDeserializer<'de> {
         V: Visitor<'de>,
     {
         match self.value {
-            Some(&Value::Array(ref v)) => {
+            Some(Value::Array(v)) => {
                 if v.is_empty() {
                     visitor.visit_unit()
                 } else {
@@ -1021,7 +1021,7 @@ impl<'de> VariantAccess<'de> for VariantRefDeserializer<'de> {
         V: Visitor<'de>,
     {
         match self.value {
-            Some(&Value::Object(ref v)) => visit_object_ref(v, visitor),
+            Some(Value::Object(v)) => visit_object_ref(v, visitor),
             Some(other) => Err(serde::de::Error::invalid_type(
                 other.unexpected(),
                 &"struct variant",
@@ -1150,15 +1150,12 @@ impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
     deserialize_integer_key!(deserialize_i16 => visit_i16);
     deserialize_integer_key!(deserialize_i32 => visit_i32);
     deserialize_integer_key!(deserialize_i64 => visit_i64);
+    deserialize_integer_key!(deserialize_i128 => visit_i128);
     deserialize_integer_key!(deserialize_u8 => visit_u8);
     deserialize_integer_key!(deserialize_u16 => visit_u16);
     deserialize_integer_key!(deserialize_u32 => visit_u32);
     deserialize_integer_key!(deserialize_u64 => visit_u64);
-
-    serde_if_integer128! {
-        deserialize_integer_key!(deserialize_i128 => visit_i128);
-        deserialize_integer_key!(deserialize_u128 => visit_u128);
-    }
+    deserialize_integer_key!(deserialize_u128 => visit_u128);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
@@ -1268,11 +1265,11 @@ impl Value {
 
     #[cold]
     fn unexpected(&self) -> Unexpected {
-        match *self {
+        match self {
             Value::Null => Unexpected::Unit,
-            Value::Bool(b) => Unexpected::Bool(b),
-            Value::Number(ref n) => n.unexpected(),
-            Value::String(ref s) => Unexpected::Str(s),
+            Value::Bool(b) => Unexpected::Bool(*b),
+            Value::Number(n) => n.unexpected(),
+            Value::String(s) => Unexpected::Str(s),
             Value::Array(_) => Unexpected::Seq,
             Value::Object(_) => Unexpected::Map,
         }

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,11 +1,10 @@
 use super::Value;
-use crate::lib::iter::FromIterator;
-use crate::lib::*;
 use crate::map::Map;
 use crate::number::Number;
-
-#[cfg(feature = "arbitrary_precision")]
-use serde::serde_if_integer128;
+use alloc::borrow::Cow;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::iter::FromIterator;
 
 macro_rules! from_integer {
     ($($ty:ident)*) => {
@@ -25,10 +24,8 @@ from_integer! {
 }
 
 #[cfg(feature = "arbitrary_precision")]
-serde_if_integer128! {
-    from_integer! {
-        i128 u128
-    }
+from_integer! {
+    i128 u128
 }
 
 impl From<f32> for Value {
@@ -43,7 +40,7 @@ impl From<f32> for Value {
     /// let x: Value = f.into();
     /// ```
     fn from(f: f32) -> Self {
-        From::from(f as f64)
+        Number::from_f32(f).map_or(Value::Null, Value::Number)
     }
 }
 
@@ -264,5 +261,17 @@ impl From<()> for Value {
     /// ```
     fn from((): ()) -> Self {
         Value::Null
+    }
+}
+
+impl<T> From<Option<T>> for Value
+where
+    T: Into<Value>,
+{
+    fn from(opt: Option<T>) -> Self {
+        match opt {
+            None => Value::Null,
+            Some(value) => Into::into(value),
+        }
     }
 }

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,6 +1,9 @@
 use super::Value;
-use crate::lib::*;
 use crate::map::Map;
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use core::fmt::{self, Display};
+use core::ops;
 
 /// A type that can be used to index into a `serde_json_lenient::Value`.
 ///
@@ -50,20 +53,20 @@ pub trait Index: private::Sealed {
 
 impl Index for usize {
     fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
-        match *v {
-            Value::Array(ref vec) => vec.get(*self),
+        match v {
+            Value::Array(vec) => vec.get(*self),
             _ => None,
         }
     }
     fn index_into_mut<'v>(&self, v: &'v mut Value) -> Option<&'v mut Value> {
-        match *v {
-            Value::Array(ref mut vec) => vec.get_mut(*self),
+        match v {
+            Value::Array(vec) => vec.get_mut(*self),
             _ => None,
         }
     }
     fn index_or_insert<'v>(&self, v: &'v mut Value) -> &'v mut Value {
-        match *v {
-            Value::Array(ref mut vec) => {
+        match v {
+            Value::Array(vec) => {
                 let len = vec.len();
                 vec.get_mut(*self).unwrap_or_else(|| {
                     panic!(
@@ -79,23 +82,23 @@ impl Index for usize {
 
 impl Index for str {
     fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
-        match *v {
-            Value::Object(ref map) => map.get(self),
+        match v {
+            Value::Object(map) => map.get(self),
             _ => None,
         }
     }
     fn index_into_mut<'v>(&self, v: &'v mut Value) -> Option<&'v mut Value> {
-        match *v {
-            Value::Object(ref mut map) => map.get_mut(self),
+        match v {
+            Value::Object(map) => map.get_mut(self),
             _ => None,
         }
     }
     fn index_or_insert<'v>(&self, v: &'v mut Value) -> &'v mut Value {
-        if let Value::Null = *v {
+        if let Value::Null = v {
             *v = Value::Object(Map::new());
         }
-        match *v {
-            Value::Object(ref mut map) => map.entry(self.to_owned()).or_insert(Value::Null),
+        match v {
+            Value::Object(map) => map.entry(self.to_owned()).or_insert(Value::Null),
             _ => panic!("cannot access key {:?} in JSON {}", self, Type(v)),
         }
     }
@@ -133,14 +136,14 @@ mod private {
     pub trait Sealed {}
     impl Sealed for usize {}
     impl Sealed for str {}
-    impl Sealed for super::String {}
+    impl Sealed for alloc::string::String {}
     impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
 }
 
 /// Used in panic messages.
 struct Type<'a>(&'a Value);
 
-impl<'a> fmt::Display for Type<'a> {
+impl<'a> Display for Type<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match *self.0 {
             Value::Null => formatter.write_str("null"),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -85,14 +85,18 @@
 //! # untyped_example().unwrap();
 //! ```
 //!
-//! [macro]: https://docs.serde.rs/serde_json_lenient/macro.json.html
-//! [from_str]: https://docs.serde.rs/serde_json_lenient/de/fn.from_str.html
-//! [from_slice]: https://docs.serde.rs/serde_json_lenient/de/fn.from_slice.html
-//! [from_reader]: https://docs.serde.rs/serde_json_lenient/de/fn.from_reader.html
+//! [macro]: crate::json
+//! [from_str]: crate::de::from_str
+//! [from_slice]: crate::de::from_slice
+//! [from_reader]: crate::de::from_reader
 
 use crate::error::Error;
 use crate::io;
-use crate::lib::*;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt::{self, Debug, Display};
+use core::mem;
+use core::str;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
@@ -172,26 +176,24 @@ pub enum Value {
 
 impl Debug for Value {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Value::Null => formatter.debug_tuple("Null").finish(),
-            Value::Bool(v) => formatter.debug_tuple("Bool").field(&v).finish(),
-            Value::Number(ref v) => Debug::fmt(v, formatter),
-            Value::String(ref v) => formatter.debug_tuple("String").field(v).finish(),
-            Value::Array(ref v) => {
-                formatter.write_str("Array(")?;
-                Debug::fmt(v, formatter)?;
-                formatter.write_str(")")
+        match self {
+            Value::Null => formatter.write_str("Null"),
+            Value::Bool(boolean) => write!(formatter, "Bool({})", boolean),
+            Value::Number(number) => Debug::fmt(number, formatter),
+            Value::String(string) => write!(formatter, "String({:?})", string),
+            Value::Array(vec) => {
+                formatter.write_str("Array ")?;
+                Debug::fmt(vec, formatter)
             }
-            Value::Object(ref v) => {
-                formatter.write_str("Object(")?;
-                Debug::fmt(v, formatter)?;
-                formatter.write_str(")")
+            Value::Object(map) => {
+                formatter.write_str("Object ")?;
+                Debug::fmt(map, formatter)
             }
         }
     }
 }
 
-impl fmt::Display for Value {
+impl Display for Value {
     /// Display a JSON value as a string.
     ///
     /// ```
@@ -361,8 +363,8 @@ impl Value {
     /// assert_eq!(v["b"].as_object(), None);
     /// ```
     pub fn as_object(&self) -> Option<&Map<String, Value>> {
-        match *self {
-            Value::Object(ref map) => Some(map),
+        match self {
+            Value::Object(map) => Some(map),
             _ => None,
         }
     }
@@ -379,8 +381,8 @@ impl Value {
     /// assert_eq!(v, json!({ "a": {} }));
     /// ```
     pub fn as_object_mut(&mut self) -> Option<&mut Map<String, Value>> {
-        match *self {
-            Value::Object(ref mut map) => Some(map),
+        match self {
+            Value::Object(map) => Some(map),
             _ => None,
         }
     }
@@ -420,8 +422,8 @@ impl Value {
     /// assert_eq!(v["b"].as_array(), None);
     /// ```
     pub fn as_array(&self) -> Option<&Vec<Value>> {
-        match *self {
-            Value::Array(ref array) => Some(&*array),
+        match self {
+            Value::Array(array) => Some(array),
             _ => None,
         }
     }
@@ -438,8 +440,8 @@ impl Value {
     /// assert_eq!(v, json!({ "a": [] }));
     /// ```
     pub fn as_array_mut(&mut self) -> Option<&mut Vec<Value>> {
-        match *self {
-            Value::Array(ref mut list) => Some(list),
+        match self {
+            Value::Array(list) => Some(list),
             _ => None,
         }
     }
@@ -487,8 +489,8 @@ impl Value {
     /// println!("The value is: {}", v["a"].as_str().unwrap());
     /// ```
     pub fn as_str(&self) -> Option<&str> {
-        match *self {
-            Value::String(ref s) => Some(s),
+        match self {
+            Value::String(s) => Some(s),
             _ => None,
         }
     }
@@ -533,8 +535,8 @@ impl Value {
     /// assert!(!v["c"].is_i64());
     /// ```
     pub fn is_i64(&self) -> bool {
-        match *self {
-            Value::Number(ref n) => n.is_i64(),
+        match self {
+            Value::Number(n) => n.is_i64(),
             _ => false,
         }
     }
@@ -558,8 +560,8 @@ impl Value {
     /// assert!(!v["c"].is_u64());
     /// ```
     pub fn is_u64(&self) -> bool {
-        match *self {
-            Value::Number(ref n) => n.is_u64(),
+        match self {
+            Value::Number(n) => n.is_u64(),
             _ => false,
         }
     }
@@ -584,8 +586,8 @@ impl Value {
     /// assert!(!v["c"].is_f64());
     /// ```
     pub fn is_f64(&self) -> bool {
-        match *self {
-            Value::Number(ref n) => n.is_f64(),
+        match self {
+            Value::Number(n) => n.is_f64(),
             _ => false,
         }
     }
@@ -604,8 +606,8 @@ impl Value {
     /// assert_eq!(v["c"].as_i64(), None);
     /// ```
     pub fn as_i64(&self) -> Option<i64> {
-        match *self {
-            Value::Number(ref n) => n.as_i64(),
+        match self {
+            Value::Number(n) => n.as_i64(),
             _ => None,
         }
     }
@@ -623,8 +625,8 @@ impl Value {
     /// assert_eq!(v["c"].as_u64(), None);
     /// ```
     pub fn as_u64(&self) -> Option<u64> {
-        match *self {
-            Value::Number(ref n) => n.as_u64(),
+        match self {
+            Value::Number(n) => n.as_u64(),
             _ => None,
         }
     }
@@ -642,8 +644,8 @@ impl Value {
     /// assert_eq!(v["c"].as_f64(), Some(-64.0));
     /// ```
     pub fn as_f64(&self) -> Option<f64> {
-        match *self {
-            Value::Number(ref n) => n.as_f64(),
+        match self {
+            Value::Number(n) => n.as_f64(),
             _ => None,
         }
     }

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,5 +1,5 @@
 use super::Value;
-use crate::lib::*;
+use alloc::string::String;
 
 fn eq_i64(value: &Value, other: i64) -> bool {
     value.as_i64().map_or(false, |i| i == other)
@@ -7,6 +7,13 @@ fn eq_i64(value: &Value, other: i64) -> bool {
 
 fn eq_u64(value: &Value, other: u64) -> bool {
     value.as_u64().map_or(false, |i| i == other)
+}
+
+fn eq_f32(value: &Value, other: f32) -> bool {
+    match value {
+        Value::Number(n) => n.as_f32().map_or(false, |i| i == other),
+        _ => false,
+    }
 }
 
 fn eq_f64(value: &Value, other: f64) -> bool {
@@ -90,6 +97,7 @@ macro_rules! partialeq_numeric {
 partialeq_numeric! {
     eq_i64[i8 i16 i32 i64 isize]
     eq_u64[u8 u16 u32 u64 usize]
-    eq_f64[f32 f64]
+    eq_f32[f32]
+    eq_f64[f64]
     eq_bool[bool]
 }

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,12 +1,14 @@
 use crate::error::{Error, ErrorCode, Result};
-use crate::lib::*;
 use crate::map::Map;
-use crate::number::Number;
 use crate::value::{to_value, Value};
+use alloc::borrow::ToOwned;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+#[cfg(not(feature = "arbitrary_precision"))]
+use core::convert::TryFrom;
+use core::fmt::Display;
+use core::result;
 use serde::ser::{Impossible, Serialize};
-
-#[cfg(feature = "arbitrary_precision")]
-use serde::serde_if_integer128;
 
 impl Serialize for Value {
     #[inline]
@@ -14,14 +16,14 @@ impl Serialize for Value {
     where
         S: ::serde::Serializer,
     {
-        match *self {
+        match self {
             Value::Null => serializer.serialize_unit(),
-            Value::Bool(b) => serializer.serialize_bool(b),
-            Value::Number(ref n) => n.serialize(serializer),
-            Value::String(ref s) => serializer.serialize_str(s),
-            Value::Array(ref v) => v.serialize(serializer),
+            Value::Bool(b) => serializer.serialize_bool(*b),
+            Value::Number(n) => n.serialize(serializer),
+            Value::String(s) => serializer.serialize_str(s),
+            Value::Array(v) => v.serialize(serializer),
             #[cfg(any(feature = "std", feature = "alloc"))]
-            Value::Object(ref m) => {
+            Value::Object(m) => {
                 use serde::ser::SerializeMap;
                 let mut map = tri!(serializer.serialize_map(Some(m.len())));
                 for (k, v) in m {
@@ -91,10 +93,21 @@ impl serde::Serializer for Serializer {
         Ok(Value::Number(value.into()))
     }
 
-    #[cfg(feature = "arbitrary_precision")]
-    serde_if_integer128! {
-        fn serialize_i128(self, value: i128) -> Result<Value> {
+    fn serialize_i128(self, value: i128) -> Result<Value> {
+        #[cfg(feature = "arbitrary_precision")]
+        {
             Ok(Value::Number(value.into()))
+        }
+
+        #[cfg(not(feature = "arbitrary_precision"))]
+        {
+            if let Ok(value) = u64::try_from(value) {
+                Ok(Value::Number(value.into()))
+            } else if let Ok(value) = i64::try_from(value) {
+                Ok(Value::Number(value.into()))
+            } else {
+                Err(Error::syntax(ErrorCode::NumberOutOfRange, 0, 0))
+            }
         }
     }
 
@@ -118,21 +131,30 @@ impl serde::Serializer for Serializer {
         Ok(Value::Number(value.into()))
     }
 
-    #[cfg(feature = "arbitrary_precision")]
-    serde_if_integer128! {
-        fn serialize_u128(self, value: u128) -> Result<Value> {
+    fn serialize_u128(self, value: u128) -> Result<Value> {
+        #[cfg(feature = "arbitrary_precision")]
+        {
             Ok(Value::Number(value.into()))
+        }
+
+        #[cfg(not(feature = "arbitrary_precision"))]
+        {
+            if let Ok(value) = u64::try_from(value) {
+                Ok(Value::Number(value.into()))
+            } else {
+                Err(Error::syntax(ErrorCode::NumberOutOfRange, 0, 0))
+            }
         }
     }
 
     #[inline]
-    fn serialize_f32(self, value: f32) -> Result<Value> {
-        self.serialize_f64(value as f64)
+    fn serialize_f32(self, float: f32) -> Result<Value> {
+        Ok(Value::from(float))
     }
 
     #[inline]
-    fn serialize_f64(self, value: f64) -> Result<Value> {
-        Ok(Number::from_f64(value).map_or(Value::Null, Value::Number))
+    fn serialize_f64(self, float: f64) -> Result<Value> {
+        Ok(Value::from(float))
     }
 
     #[inline]
@@ -191,7 +213,7 @@ impl serde::Serializer for Serializer {
         T: ?Sized + Serialize,
     {
         let mut values = Map::new();
-        values.insert(String::from(variant), tri!(to_value(&value)));
+        values.insert(String::from(variant), tri!(to_value(value)));
         Ok(Value::Object(values))
     }
 
@@ -269,9 +291,9 @@ impl serde::Serializer for Serializer {
         })
     }
 
-    fn collect_str<T: ?Sized>(self, value: &T) -> Result<Value>
+    fn collect_str<T>(self, value: &T) -> Result<Value>
     where
-        T: Display,
+        T: ?Sized + Display,
     {
         Ok(Value::String(value.to_string()))
     }
@@ -310,7 +332,7 @@ impl serde::ser::SerializeSeq for SerializeVec {
     where
         T: ?Sized + Serialize,
     {
-        self.vec.push(tri!(to_value(&value)));
+        self.vec.push(tri!(to_value(value)));
         Ok(())
     }
 
@@ -359,7 +381,7 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     where
         T: ?Sized + Serialize,
     {
-        self.vec.push(tri!(to_value(&value)));
+        self.vec.push(tri!(to_value(value)));
         Ok(())
     }
 
@@ -380,10 +402,8 @@ impl serde::ser::SerializeMap for SerializeMap {
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            SerializeMap::Map {
-                ref mut next_key, ..
-            } => {
+        match self {
+            SerializeMap::Map { next_key, .. } => {
                 *next_key = Some(tri!(key.serialize(MapKeySerializer)));
                 Ok(())
             }
@@ -398,16 +418,13 @@ impl serde::ser::SerializeMap for SerializeMap {
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            SerializeMap::Map {
-                ref mut map,
-                ref mut next_key,
-            } => {
+        match self {
+            SerializeMap::Map { map, next_key } => {
                 let key = next_key.take();
                 // Panic because this indicates a bug in the program rather than an
                 // expected failure.
                 let key = key.expect("serialize_value called before serialize_key");
-                map.insert(key, tri!(to_value(&value)));
+                map.insert(key, tri!(to_value(value)));
                 Ok(())
             }
             #[cfg(feature = "arbitrary_precision")]
@@ -602,9 +619,9 @@ impl serde::Serializer for MapKeySerializer {
         Err(key_must_be_a_string())
     }
 
-    fn collect_str<T: ?Sized>(self, value: &T) -> Result<String>
+    fn collect_str<T>(self, value: &T) -> Result<String>
     where
-        T: Display,
+        T: ?Sized + Display,
     {
         Ok(value.to_string())
     }
@@ -618,10 +635,10 @@ impl serde::ser::SerializeStruct for SerializeMap {
     where
         T: ?Sized + Serialize,
     {
-        match *self {
+        match self {
             SerializeMap::Map { .. } => serde::ser::SerializeMap::serialize_entry(self, key, value),
             #[cfg(feature = "arbitrary_precision")]
-            SerializeMap::Number { ref mut out_value } => {
+            SerializeMap::Number { out_value } => {
                 if key == crate::number::TOKEN {
                     *out_value = Some(value.serialize(NumberValueEmitter)?);
                     Ok(())
@@ -630,7 +647,7 @@ impl serde::ser::SerializeStruct for SerializeMap {
                 }
             }
             #[cfg(feature = "raw_value")]
-            SerializeMap::RawValue { ref mut out_value } => {
+            SerializeMap::RawValue { out_value } => {
                 if key == crate::raw::TOKEN {
                     *out_value = Some(value.serialize(RawValueEmitter)?);
                     Ok(())
@@ -664,7 +681,7 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
     where
         T: ?Sized + Serialize,
     {
-        self.map.insert(String::from(key), tri!(to_value(&value)));
+        self.map.insert(String::from(key), tri!(to_value(value)));
         Ok(())
     }
 
@@ -1015,5 +1032,12 @@ impl serde::ser::Serializer for RawValueEmitter {
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         Err(invalid_raw_value())
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Display,
+    {
+        self.serialize_str(&value.to_string())
     }
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,4 +1,5 @@
 #[rustversion::attr(not(nightly), ignore)]
+#[cfg_attr(miri, ignore)]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/tests/crate/Cargo.toml
+++ b/tests/crate/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "serde_json_test"
 version = "0.0.0"
+authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"
 publish = false
 

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use serde_json_lenient::{json, Number, Value};
 
 #[test]
@@ -26,6 +27,8 @@ fn value_number() {
     assert_eq!(format!("{:?}", json!(1)), "Number(1)");
     assert_eq!(format!("{:?}", json!(-1)), "Number(-1)");
     assert_eq!(format!("{:?}", json!(1.0)), "Number(1.0)");
+    assert_eq!(Number::from_f64(1.0).unwrap().to_string(), "1.0"); // not just "1"
+    assert_eq!(Number::from_f64(12e40).unwrap().to_string(), "1.2e41");
 }
 
 #[test]
@@ -35,12 +38,12 @@ fn value_string() {
 
 #[test]
 fn value_array() {
-    assert_eq!(format!("{:?}", json!([])), "Array([])");
+    assert_eq!(format!("{:?}", json!([])), "Array []");
 }
 
 #[test]
 fn value_object() {
-    assert_eq!(format!("{:?}", json!({})), "Object({})");
+    assert_eq!(format!("{:?}", json!({})), "Object {}");
 }
 
 #[test]
@@ -50,19 +53,29 @@ fn error() {
     assert_eq!(format!("{:?}", err), expected);
 }
 
-const INDENTED_EXPECTED: &str = r#"Object({
-    "array": Array([
-        Number(
-            0,
-        ),
-        Number(
-            1,
-        ),
-    ]),
-})"#;
-
 #[test]
 fn indented() {
-    let j = json!({ "array": [0, 1] });
-    assert_eq!(format!("{:#?}", j), INDENTED_EXPECTED);
+    let j = json!({
+        "Array": [true],
+        "Bool": true,
+        "EmptyArray": [],
+        "EmptyObject": {},
+        "Null": null,
+        "Number": 1,
+        "String": "...",
+    });
+    let expected = indoc! {r#"
+        Object {
+            "Array": Array [
+                Bool(true),
+            ],
+            "Bool": Bool(true),
+            "EmptyArray": Array [],
+            "EmptyObject": Object {},
+            "Null": Null,
+            "Number": Number(1),
+            "String": String("..."),
+        }"#
+    };
+    assert_eq!(format!("{:#?}", j), expected);
 }

--- a/tests/invalid_characters.rs
+++ b/tests/invalid_characters.rs
@@ -26,11 +26,7 @@ fn test_invalid_characters() {
 
 #[test]
 fn test_invalid_utf16_escape_sequence() {
-    let s = r#"
-    {
-        "key": "value\ud800"
-    }"#
-    .as_bytes();
+    let s = "{\"key\": \"value\\udfff\"}".as_bytes();
     let value: Value = from_slice_with_unicode_substitution(&s).unwrap();
     assert_eq!(value, json!({"key": "value\u{fffd}"}));
 }

--- a/tests/lexical.rs
+++ b/tests/lexical.rs
@@ -9,7 +9,9 @@
     clippy::excessive_precision,
     clippy::float_cmp,
     clippy::if_not_else,
+    clippy::let_underscore_untyped,
     clippy::module_name_repetitions,
+    clippy::needless_late_init,
     clippy::shadow_unrelated,
     clippy::similar_names,
     clippy::single_match_else,
@@ -18,6 +20,8 @@
     clippy::unseparated_literal_suffix,
     clippy::wildcard_imports
 )]
+
+extern crate alloc;
 
 #[path = "../src/lexical/mod.rs"]
 mod lexical;

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused_macro_rules)]
+
 macro_rules! json_str {
     ([]) => {
         "[]"

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -34,3 +34,14 @@ fn test_append() {
     assert_eq!(keys, EXPECTED);
     assert!(val.is_empty());
 }
+
+#[cfg(not(no_btreemap_retain))]
+#[test]
+fn test_retain() {
+    let mut v: Value = from_str(r#"{"b":null,"a":null,"c":null}"#).unwrap();
+    let val = v.as_object_mut().unwrap();
+    val.retain(|k, _| k.as_str() != "b");
+
+    let keys: Vec<_> = val.keys().collect();
+    assert_eq!(keys, &["a", "c"]);
+}

--- a/tests/regression/issue1004.rs
+++ b/tests/regression/issue1004.rs
@@ -1,0 +1,12 @@
+#![cfg(feature = "arbitrary_precision")]
+
+#[test]
+fn test() {
+    let float = 5.55f32;
+    let value = serde_json::to_value(float).unwrap();
+    let json = serde_json::to_string(&value).unwrap();
+
+    // If the f32 were cast to f64 by Value before serialization, then this
+    // would incorrectly serialize as 5.550000190734863.
+    assert_eq!(json, "5.55");
+}

--- a/tests/regression/issue795.rs
+++ b/tests/regression/issue795.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::assertions_on_result_states)]
+
 use serde::de::{
     Deserialize, Deserializer, EnumAccess, IgnoredAny, MapAccess, VariantAccess, Visitor,
 };

--- a/tests/regression/issue845.rs
+++ b/tests/regression/issue845.rs
@@ -1,0 +1,74 @@
+#![allow(clippy::trait_duplication_in_bounds)] // https://github.com/rust-lang/rust-clippy/issues/8757
+
+use serde::{Deserialize, Deserializer};
+use std::convert::TryFrom;
+use std::fmt::{self, Display};
+use std::marker::PhantomData;
+use std::str::FromStr;
+
+pub struct NumberVisitor<T> {
+    marker: PhantomData<T>,
+}
+
+impl<'de, T> serde::de::Visitor<'de> for NumberVisitor<T>
+where
+    T: TryFrom<u64> + TryFrom<i64> + FromStr,
+    <T as TryFrom<u64>>::Error: Display,
+    <T as TryFrom<i64>>::Error: Display,
+    <T as FromStr>::Err: Display,
+{
+    type Value = T;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an integer or string")
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        T::try_from(v).map_err(serde::de::Error::custom)
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        T::try_from(v).map_err(serde::de::Error::custom)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        v.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+fn deserialize_integer_or_string<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: TryFrom<u64> + TryFrom<i64> + FromStr,
+    <T as TryFrom<u64>>::Error: Display,
+    <T as TryFrom<i64>>::Error: Display,
+    <T as FromStr>::Err: Display,
+{
+    deserializer.deserialize_any(NumberVisitor {
+        marker: PhantomData,
+    })
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Struct {
+    #[serde(deserialize_with = "deserialize_integer_or_string")]
+    pub i: i64,
+}
+
+#[test]
+fn test() {
+    let j = r#" {"i":100} "#;
+    println!("{:?}", serde_json_lenient::from_str::<Struct>(j).unwrap());
+
+    let j = r#" {"i":"100"} "#;
+    println!("{:?}", serde_json_lenient::from_str::<Struct>(j).unwrap());
+}

--- a/tests/regression/issue953.rs
+++ b/tests/regression/issue953.rs
@@ -1,0 +1,9 @@
+use serde_json_lenient::Value;
+
+#[test]
+fn test() {
+    let x1 = serde_json_lenient::from_str::<Value>("18446744073709551615.");
+    assert!(x1.is_err());
+    let x2 = serde_json_lenient::from_str::<Value>("18446744073709551616.");
+    assert!(x2.is_err());
+}

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,4 +1,5 @@
 #![cfg(not(feature = "preserve_order"))]
+#![allow(clippy::assertions_on_result_states)]
 
 use serde_json_lenient::{json, Deserializer, Value};
 

--- a/tests/ui/missing_colon.stderr
+++ b/tests/ui/missing_colon.stderr
@@ -4,4 +4,9 @@ error: unexpected end of macro invocation
 4 |     json!({ "a" });
   |     ^^^^^^^^^^^^^^ missing tokens in macro arguments
   |
-  = note: this error originates in the macro `json_internal` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: while trying to match `@`
+ --> src/macros.rs
+  |
+  |     (@array [$($elems:expr,)*]) => {
+  |      ^
+  = note: this error originates in the macro `json_internal` which comes from the expansion of the macro `json` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/missing_comma.stderr
+++ b/tests/ui/missing_comma.stderr
@@ -5,3 +5,9 @@ error: no rules expected the token `"2"`
   |                    -^^^ no rules expected this token in macro call
   |                    |
   |                    help: missing comma here
+  |
+note: while trying to match `,`
+ --> src/macros.rs
+  |
+  |     ($e:expr , $($tt:tt)*) => {};
+  |              ^

--- a/tests/ui/missing_value.stderr
+++ b/tests/ui/missing_value.stderr
@@ -4,4 +4,9 @@ error: unexpected end of macro invocation
 4 |     json!({ "a" : });
   |     ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
   |
-  = note: this error originates in the macro `json_internal` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: while trying to match `@`
+ --> src/macros.rs
+  |
+  |     (@array [$($elems:expr,)*]) => {
+  |      ^
+  = note: this error originates in the macro `json_internal` which comes from the expansion of the macro `json` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/parse_expr.stderr
+++ b/tests/ui/parse_expr.stderr
@@ -3,3 +3,9 @@ error: no rules expected the token `~`
   |
 4 |     json!({ "a" : ~ });
   |                   ^ no rules expected this token in macro call
+  |
+note: while trying to match meta-variable `$e:expr`
+ --> src/macros.rs
+  |
+  |     ($e:expr , $($tt:tt)*) => {};
+  |      ^^^^^^^

--- a/tests/ui/unexpected_after_array_element.stderr
+++ b/tests/ui/unexpected_after_array_element.stderr
@@ -3,3 +3,5 @@ error: no rules expected the token `=>`
   |
 4 |     json!([ true => ]);
   |                  ^^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_after_map_entry.stderr
+++ b/tests/ui/unexpected_after_map_entry.stderr
@@ -3,3 +3,5 @@ error: no rules expected the token `=>`
   |
 4 |     json!({ "k": true => });
   |                       ^^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_colon.stderr
+++ b/tests/ui/unexpected_colon.stderr
@@ -3,3 +3,5 @@ error: no rules expected the token `:`
   |
 4 |     json!({ : true });
   |             ^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_comma.stderr
+++ b/tests/ui/unexpected_comma.stderr
@@ -3,3 +3,5 @@ error: no rules expected the token `,`
   |
 4 |     json!({ "a" , "b": true });
   |                 ^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro


### PR DESCRIPTION
Upgrade serde_json to v1.0.96 primarily to solve continuous CI fails with older serde_json versions and modern rust.

This also:
* fixes a serde_json_lenient test which appears to have always been wrong
* removes a previous change which disabled clippy from CI