### PR TITLE
Escaped non-characters are converted to �, but literals are not

### DIFF
--- a/tests/non_characters.rs
+++ b/tests/non_characters.rs
@@ -6,11 +6,18 @@ extern crate serde_json_lenient;
 use serde_json_lenient::{from_str, Value};
 
 #[test]
-fn test_non_character() {
+fn test_escaped_non_character() {
     let s = r#"
     {
         "key": "value\ufdef\uffff"
     }"#;
     let value: Value = from_str(s).unwrap();
     assert_eq!(value, json!({"key": "value\u{fffd}\u{fffd}"}));
+}
+
+#[test]
+fn test_literal_non_character() {
+    let s = "{\"key\": \"value\u{fdd0}\"}";
+    let value: Value = from_str(s).unwrap();
+    assert_eq!(value, json!({"key": "value\u{fffd}"}));
 }


### PR DESCRIPTION
Hopefully the attached test makes the distinction clear. This seems inconsistent, and differs from the behavior of the C++ parser in Chromium, at least.

I see this comment https://github.com/google/serde_json_lenient/blob/0f681383fff67ab2a31b6bff0724cf7a4cf49766/src/read.rs#L1132-L1133
but it doesn't appear to be very optional!

Should this be a new variant of JSON, or should this inconsistency be made consistent one way or the other?

/cc @adetaylor as we've discussed the beginning of this issue.