### PR TITLE
Do not discard the byte after a high surrogate

### DIFF
--- a/tests/invalid_characters.rs
+++ b/tests/invalid_characters.rs
@@ -25,8 +25,15 @@ fn test_invalid_characters() {
 }
 
 #[test]
-fn test_invalid_utf16_escape_sequence() {
-    let s = "{\"key\": \"value\\udfff\"}".as_bytes();
+fn test_invalid_utf16_escape_sequence_lone_low_surrogate() {
+    let s = "{\"key\": \"value=\\udfff_\"}".as_bytes();
     let value: Value = from_slice_with_unicode_substitution(s).unwrap();
-    assert_eq!(value, json!({"key": "value\u{fffd}"}));
+    assert_eq!(value, json!({"key": "value=\u{fffd}_"}));
+}
+
+#[test]
+fn test_invalid_utf16_escape_sequence_lone_high_surrogate() {
+    let s = "{\"key\": \"value=\\ud800_\"}".as_bytes();
+    let value: Value = from_slice_with_unicode_substitution(s).unwrap();
+    assert_eq!(value, json!({"key": "value=\u{fffd}_"}));
 }


### PR DESCRIPTION
Given "\ud800X", containing an invalid lone high surrogate, the `X` is peeked at to see if it is a `\`. If it is not, it should not be consumed (discarded).

This fixes one more error caught by the Chromium test suite.