### PR TITLE
Improve performance of escape character checking

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -601,8 +601,11 @@ impl<'a> SliceRead<'a> {
         }
     }
 
-    fn escapes(&self) -> [bool; 256] {
-        get_escapes(self.allow_control_characters_in_string)
+    fn escapes(&self) -> &[bool; 256] {
+        if self.allow_control_characters_in_string {
+            return &NO_ESCAPE;
+        }
+        &ESCAPE
     }
 
     fn position_of_index(&self, i: usize) -> Position {
@@ -1018,6 +1021,7 @@ impl<'a> Fused for StrRead<'a> {}
 
 #[cfg(feature = "std")]
 const ESCAPE: [bool; 256] = get_escapes(false);
+const NO_ESCAPE: [bool; 256] = get_escapes(true);
 
 // Lookup table of bytes that must be escaped. A value of true at index i means
 // that byte i requires an escape sequence in the input.

--- a/src/read.rs
+++ b/src/read.rs
@@ -1019,7 +1019,6 @@ pub trait Fused: private::Sealed {}
 impl<'a> Fused for SliceRead<'a> {}
 impl<'a> Fused for StrRead<'a> {}
 
-#[cfg(feature = "std")]
 const ESCAPE: [bool; 256] = get_escapes(false);
 const NO_ESCAPE: [bool; 256] = get_escapes(true);
 


### PR DESCRIPTION
Prior to this change, the escapes function in read.rs constructs and returns-by-copy an array of bools for each character processed inside a string by SliceRead.
This change constructs both of the possible arrays that escapes can return once, and then changes escapes to return references to them.

On citm_catalog.json (a fairly representative benchmarking input with a mix of types), this change reduces parsing time by about 15%. On twitter.json (a string-heavy benchmark), this change reduces parsing time by 37%.