### PR TITLE
Create parse_negative_zero_as_int cfg flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - run: cargo test --features float_roundtrip,arbitrary_precision --tests -- --skip ui --exact
       - run: cargo test --features raw_value --tests -- --skip ui --exact
       - run: cargo test --features unbounded_depth --tests -- --skip ui --exact
+      - run: cargo test --features parse_negative_zero_as_int --tests -- --skip ui --exact
 
   build:
     name: Rust ${{matrix.rust}} ${{matrix.os == 'windows' && '(windows)' || ''}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,8 @@ raw_value = []
 # overflow the stack after deserialization has completed, including, but not
 # limited to, Display and Debug and Drop impls.
 unbounded_depth = []
+
+# Parse -0 as an integer, meant primarily for compatibility with existing JSON
+# parsers. Serde traditionally parses -0 as a "real", and will produce -0.0.
+# With this flag, it is parsed as an int, and becomes 0.
+parse_negative_zero_as_int = []

--- a/src/de.rs
+++ b/src/de.rs
@@ -615,7 +615,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
 
                     // If we have -0 and cfg parse_negative_zero_as_int is true, then we handle -0
                     // as an i64 (0). Otherwise, -0 becomes an f64 (-0.0).
-                    let parse_as_float = if cfg!(parse_negative_zero_as_int) {
+                    let parse_as_float = if cfg!(feature = "parse_negative_zero_as_int") {
                         neg > 0
                     } else {
                         neg >= 0

--- a/src/de.rs
+++ b/src/de.rs
@@ -615,13 +615,13 @@ impl<'de, R: Read<'de>> Deserializer<R> {
 
                     // If we have -0 and cfg parse_negative_zero_as_int is true, then we handle -0
                     // as an i64 (0). Otherwise, -0 becomes an f64 (-0.0).
-                    let parse_with_zero = if cfg!(parse_negative_zero_as_int) {
+                    let parse_as_float = if cfg!(parse_negative_zero_as_int) {
                         neg > 0
                     } else {
                         neg >= 0
                     };
 
-                    if parse_with_zero {
+                    if parse_as_float {
                         ParserNumber::F64(-(significand as f64))
                     } else {
                         ParserNumber::I64(neg)

--- a/src/de.rs
+++ b/src/de.rs
@@ -613,8 +613,15 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                 } else {
                     let neg = (significand as i64).wrapping_neg();
 
-                    // Convert into a float if we underflow, or on `-0`.
-                    if neg >= 0 {
+                    // If we have -0 and cfg parse_negative_zero_as_int is true, then we handle -0
+                    // as an i64 (0). Otherwise, -0 becomes an f64 (-0.0).
+                    let parse_with_zero = if cfg!(parse_negative_zero_as_int) {
+                        neg > 0
+                    } else {
+                        neg >= 0
+                    };
+
+                    if parse_with_zero {
                         ParserNumber::F64(-(significand as f64))
                     } else {
                         ParserNumber::I64(neg)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1897,13 +1897,13 @@ fn test_integer_key() {
         (r#"{"123 ":null}"#, "expected `\"` at line 1 column 6"),
     ]);
 
-    let err = from_value::<BTreeMap<i32, ()>>(json!({ " 123": null })).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>>(json!({" 123":null})).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",
     );
 
-    let err = from_value::<BTreeMap<i32, ()>>(json!({ "123 ": null })).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>>(json!({"123 ":null})).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -829,9 +829,16 @@ fn test_parse_u64() {
     ]);
 }
 
+#[cfg(feature = "parse_negative_zero_as_int")]
+#[test]
+fn test_parse_negative_zero_as_int() {
+    test_parse_ok(vec![("-0", 0)]);
+}
+
 #[test]
 fn test_parse_negative_zero() {
     for negative_zero in &[
+        #[cfg(not(feature = "parse_negative_zero_as_int"))]
         "-0",
         "-0.0",
         "-0e2",
@@ -1890,13 +1897,13 @@ fn test_integer_key() {
         (r#"{"123 ":null}"#, "expected `\"` at line 1 column 6"),
     ]);
 
-    let err = from_value::<BTreeMap<i32, ()>>(json!({" 123":null})).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>>(json!({ " 123": null })).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",
     );
 
-    let err = from_value::<BTreeMap<i32, ()>>(json!({"123 ":null})).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>>(json!({ "123 ": null })).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",


### PR DESCRIPTION
Introduce cfg!(parse_negative_zero_as_int) to create a build-time option to parse -0 the same as other JSON parsers.