### PR TITLE
Add an option to control escaped newlines separately from other control

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -86,7 +86,7 @@ where
 impl<'a> Deserializer<read::SliceRead<'a>> {
     /// Creates a JSON deserializer from a `&[u8]`.
     pub fn from_slice(bytes: &'a [u8]) -> Self {
-        Deserializer::new(read::SliceRead::new(bytes, false, false, false, false))
+        Deserializer::new(read::SliceRead::new(bytes, false, false, false, false, false))
     }
 
     /// Creates a JSON deserializer from a `&[u8]`,
@@ -95,6 +95,7 @@ impl<'a> Deserializer<read::SliceRead<'a>> {
     pub fn from_slice_with_options(
         bytes: &'a [u8],
         replace_invalid_characters: bool,
+        allow_newlines_in_string: bool,
         allow_control_characters_in_string: bool,
         allow_v_escapes: bool,
         allow_x_escapes: bool,
@@ -102,6 +103,7 @@ impl<'a> Deserializer<read::SliceRead<'a>> {
         Deserializer::new(read::SliceRead::new(
             bytes,
             replace_invalid_characters,
+            allow_newlines_in_string,
             allow_control_characters_in_string,
             allow_v_escapes,
             allow_x_escapes,
@@ -2801,7 +2803,7 @@ pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    from_trait(read::SliceRead::new(v, false, false, false, false))
+    from_trait(read::SliceRead::new(v, false, false, false, false, false))
 }
 
 /// Like `from_slice`, but switches on all our quirks modes. For tests.
@@ -2810,7 +2812,7 @@ pub fn from_str_lenient<'a, T>(s: &'a str) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    from_trait(read::SliceRead::new(s.as_bytes(), true, true, true, true))
+    from_trait(read::SliceRead::new(s.as_bytes(), true, true, true, true, true))
 }
 
 /// Deserialize an instance of type `T` from a string of JSON text.

--- a/tests/control_characters.rs
+++ b/tests/control_characters.rs
@@ -3,11 +3,77 @@ extern crate serde;
 #[macro_use]
 extern crate serde_json_lenient;
 
-use serde_json_lenient::{from_str_lenient, Value};
+use serde::de::Deserialize;
+use serde_json_lenient::de::SliceRead;
+use serde_json_lenient::{from_str_lenient, Deserializer, Error, Value};
+
+struct TestOptions {
+    allow_newlines_in_string: bool,
+    allow_control_characters_in_string: bool,
+}
+
+impl TestOptions {
+    fn deserialize(&self, s: &[u8]) -> Result<Value, Error> {
+        let mut de = Deserializer::new(SliceRead::new(
+            s,
+            true,
+            self.allow_newlines_in_string,
+            self.allow_control_characters_in_string,
+            false,
+            false,
+        ));
+        Deserialize::deserialize(&mut de)
+    }
+}
 
 #[test]
-fn test_control_character() {
+fn test_control_character_lenient() {
     let s = "{ \"key\": \"a\0b\nc\" }";
     let value: Value = from_str_lenient(s).unwrap();
     assert_eq!(value, json!({"key": "a\0b\nc"}));
+}
+
+#[test]
+fn test_not_newlines_not_control() {
+    let test_options = TestOptions {
+        allow_newlines_in_string: false,
+        allow_control_characters_in_string: false,
+    };
+    assert_eq!(test_options.deserialize(b"\"abc\"").unwrap(), json!("abc"));
+    assert!(test_options.deserialize(b"\"a\nb\x10c\"").is_err());
+    assert!(test_options.deserialize(b"\"a\nb\rc\"").is_err());
+    assert!(test_options.deserialize(b"\"a\x08b\x1fc\"").is_err());
+}
+
+#[test]
+fn test_newlines_and_control() {
+    let test_options = TestOptions {
+        allow_newlines_in_string: true,
+        allow_control_characters_in_string: true,
+    };
+    assert_eq!(test_options.deserialize(b"\"abc\"").unwrap(), json!("abc"));
+    assert_eq!(
+        test_options.deserialize(b"\"a\nb\x10c\"").unwrap(),
+        json!("a\nb\x10c")
+    );
+    assert_eq!(
+        test_options.deserialize(b"\"a\nb\rc\"").unwrap(),
+        json!("a\nb\rc")
+    );
+    assert_eq!(
+        test_options.deserialize(b"\"a\x08b\x1fc\"").unwrap(),
+        json!("a\x08b\x1fc")
+    );
+}
+
+#[test]
+fn test_newlines_but_not_control() {
+    let test_options = TestOptions {
+        allow_newlines_in_string: true,
+        allow_control_characters_in_string: false,
+    };
+    assert_eq!(test_options.deserialize(b"\"abc\"").unwrap(), json!("abc"));
+    assert!(test_options.deserialize(b"\"a\nb\x10c\"").is_err());
+    assert!(test_options.deserialize(b"\"a\nb\rc\"").is_err());
+    assert!(test_options.deserialize(b"\"a\x08b\x1fc\"").is_err());
 }

--- a/tests/invalid_characters.rs
+++ b/tests/invalid_characters.rs
@@ -8,7 +8,7 @@ use serde_json_lenient::de::SliceRead;
 use serde_json_lenient::{Deserializer, Error, Value};
 
 fn from_slice_with_unicode_substitution(s: &[u8]) -> Result<Value, Error> {
-    let mut de = Deserializer::new(SliceRead::new(s, true, false, false, false));
+    let mut de = Deserializer::new(SliceRead::new(s, true, false, false, false, false));
     Deserialize::deserialize(&mut de)
 }
 


### PR DESCRIPTION
Un-escaped newlines are pretty common, while other control characters are less common. This new option allows narrowing the scope of allowed un-escaped control characters to include online CR and LF.

This is a breaking change, as it changes the number of arguments to public functions.