### PR TITLE
Newline is 0x0a, not 0x0b

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -1057,7 +1057,7 @@ const fn get_escapes(
     let CT: bool = !allow_control_characters_in_string; // other control character \x00..=\x1F
     [
         //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
-        CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, NL, CT, NL, CT, CT, // 0
+        CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, NL, CT, CT, NL, CT, CT, // 0
         CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, // 1
         __, __, QU, __, __, __, __, __, __, __, __, __, __, __, __, __, // 2
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 3

--- a/tests/control_characters.rs
+++ b/tests/control_characters.rs
@@ -35,45 +35,42 @@ fn test_control_character_lenient() {
 
 #[test]
 fn test_not_newlines_not_control() {
-    let test_options = TestOptions {
+    let opts = TestOptions {
         allow_newlines_in_string: false,
         allow_control_characters_in_string: false,
     };
-    assert_eq!(test_options.deserialize(b"\"abc\"").unwrap(), json!("abc"));
-    assert!(test_options.deserialize(b"\"a\nb\x10c\"").is_err());
-    assert!(test_options.deserialize(b"\"a\nb\rc\"").is_err());
-    assert!(test_options.deserialize(b"\"a\x08b\x1fc\"").is_err());
+    assert_eq!(opts.deserialize(b"\"abc\"").unwrap(), json!("abc"));
+    assert!(opts.deserialize(b"\"a\nb\"").is_err());
+    assert!(opts.deserialize(b"\"a\rb\"").is_err());
+    assert!(opts.deserialize(b"\"a\x10b\"").is_err());
+    assert!(opts.deserialize(b"\"a\x08b\x1fc\"").is_err());
 }
 
 #[test]
 fn test_newlines_and_control() {
-    let test_options = TestOptions {
+    let opts = TestOptions {
         allow_newlines_in_string: true,
         allow_control_characters_in_string: true,
     };
-    assert_eq!(test_options.deserialize(b"\"abc\"").unwrap(), json!("abc"));
+    assert_eq!(opts.deserialize(b"\"abc\"").unwrap(), json!("abc"));
+    assert_eq!(opts.deserialize(b"\"a\nb\"").unwrap(), json!("a\nb"));
+    assert_eq!(opts.deserialize(b"\"a\rb\"").unwrap(), json!("a\rb"));
+    assert_eq!(opts.deserialize(b"\"a\x10b\"").unwrap(), json!("a\x10b"));
     assert_eq!(
-        test_options.deserialize(b"\"a\nb\x10c\"").unwrap(),
-        json!("a\nb\x10c")
-    );
-    assert_eq!(
-        test_options.deserialize(b"\"a\nb\rc\"").unwrap(),
-        json!("a\nb\rc")
-    );
-    assert_eq!(
-        test_options.deserialize(b"\"a\x08b\x1fc\"").unwrap(),
+        opts.deserialize(b"\"a\x08b\x1fc\"").unwrap(),
         json!("a\x08b\x1fc")
     );
 }
 
 #[test]
 fn test_newlines_but_not_control() {
-    let test_options = TestOptions {
+    let opts = TestOptions {
         allow_newlines_in_string: true,
         allow_control_characters_in_string: false,
     };
-    assert_eq!(test_options.deserialize(b"\"abc\"").unwrap(), json!("abc"));
-    assert!(test_options.deserialize(b"\"a\nb\x10c\"").is_err());
-    assert!(test_options.deserialize(b"\"a\nb\rc\"").is_err());
-    assert!(test_options.deserialize(b"\"a\x08b\x1fc\"").is_err());
+    assert_eq!(opts.deserialize(b"\"abc\"").unwrap(), json!("abc"));
+    assert_eq!(opts.deserialize(b"\"a\nb\"").unwrap(), json!("a\nb"));
+    assert_eq!(opts.deserialize(b"\"a\rb\"").unwrap(), json!("a\rb"));
+    assert!(opts.deserialize(b"\"a\x10b\"").is_err());
+    assert!(opts.deserialize(b"\"a\x08b\x1fc\"").is_err());
 }


### PR DESCRIPTION
The tests didn't catch this because they always used \r and \n in the same assertion.