### PR TITLE
Correctly handle escape sequences after un-paired high surrogate escapes

### DIFF
--- a/tests/invalid_characters.rs
+++ b/tests/invalid_characters.rs
@@ -37,3 +37,17 @@ fn test_invalid_utf16_escape_sequence_lone_high_surrogate() {
     let value: Value = from_slice_with_unicode_substitution(s).unwrap();
     assert_eq!(value, json!({"key": "value=\u{fffd}_"}));
 }
+
+#[test]
+fn test_invalid_utf16_escape_sequence_lone_low_surrogate_precedes_escape() {
+    let s = "{\"key\": \"value=\\udfff\\\"x\"}".as_bytes();
+    let value: Value = from_slice_with_unicode_substitution(s).unwrap();
+    assert_eq!(value, json!({"key": "value=\u{fffd}\"x"}));
+}
+
+#[test]
+fn test_invalid_utf16_escape_sequence_lone_high_surrogate_precedes_escape() {
+    let s = "{\"key\": \"value=\\ud800\\\"x\"}".as_bytes();
+    let value: Value = from_slice_with_unicode_substitution(s).unwrap();
+    assert_eq!(value, json!({"key": "value=\u{fffd}\"x"}));
+}


### PR DESCRIPTION
Surrogate pairs should be written `\uXXXX\uYYYY`, with U+XXXX a valid high surrogate. The case where the ``` in that input is present but the `u` is absent was not handled correctly when `validate` is true and invalid characters are being replaced: once the replacement is performed, the backslash-escape was not interpreted, instead just skipping the `\`.

Fixes #28.