### PR TITLE
Update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           name: Cargo.lock
           path: Cargo.lock
+        continue-on-error: true
 
   build:
     name: Rust ${{matrix.rust}} ${{matrix.os == 'windows' && '(windows)' || ''}}
@@ -44,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [beta, 1.64.0, 1.56.1]
+        rust: [beta, 1.65.0, 1.56.1]
         os: [ubuntu]
         include:
           - rust: stable

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,6 +6,7 @@
 //! [`BTreeMap`]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
 //! [`IndexMap`]: https://docs.rs/indexmap/*/indexmap/map/struct.IndexMap.html
 
+use crate::error::Error;
 use crate::value::Value;
 use alloc::string::String;
 #[cfg(feature = "preserve_order")]
@@ -348,6 +349,29 @@ impl Map<String, Value> {
     {
         self.map.retain(f);
     }
+
+    /// Sorts this map's entries in-place using `str`'s usual ordering.
+    ///
+    /// If serde_json's "preserve_order" feature is not enabled, this method
+    /// does no work because all JSON maps are always kept in a sorted state.
+    ///
+    /// If serde_json's "preserve_order" feature is enabled, this method
+    /// destroys the original source order or insertion order of this map in
+    /// favor of an alphanumerical order that matches how a BTreeMap with the
+    /// same contents would be ordered. This takes **O(n log n + c)** time where
+    /// _n_ is the length of the map and _c_ is the capacity.
+    ///
+    /// Other maps nested within the values of this map are not sorted. If you
+    /// need the entire data structure to be sorted at all levels, you must also
+    /// call
+    /// <code>map.[values_mut]\().for_each([Value::sort_all_objects])</code>.
+    ///
+    /// [values_mut]: Map::values_mut
+    #[inline]
+    pub fn sort_keys(&mut self) {
+        #[cfg(feature = "preserve_order")]
+        self.map.sort_unstable_keys();
+    }
 }
 
 #[allow(clippy::derivable_impls)] // clippy bug: https://github.com/rust-lang/rust-clippy/issues/7655
@@ -563,6 +587,22 @@ macro_rules! delegate_iterator {
         }
 
         impl $($generics)* FusedIterator for $name $($generics)* {}
+    }
+}
+
+impl<'de> de::IntoDeserializer<'de, Error> for Map<String, Value> {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
+impl<'de> de::IntoDeserializer<'de, Error> for &'de Map<String, Value> {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
     }
 }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -11,8 +11,8 @@ use core::fmt;
 use core::slice;
 use core::str::FromStr;
 use serde::de::{
-    self, Deserialize, DeserializeSeed, EnumAccess, Expected, IntoDeserializer, MapAccess,
-    SeqAccess, Unexpected, VariantAccess, Visitor,
+    self, Deserialize, DeserializeSeed, Deserializer as _, EnumAccess, Expected, IntoDeserializer,
+    MapAccess, SeqAccess, Unexpected, VariantAccess, Visitor,
 };
 use serde::forward_to_deserialize_any;
 
@@ -44,9 +44,25 @@ impl<'de> Deserialize<'de> for Value {
                 Ok(Value::Number(value.into()))
             }
 
+            fn visit_i128<E>(self, value: i128) -> Result<Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let de = serde::de::value::I128Deserializer::new(value);
+                Number::deserialize(de).map(Value::Number)
+            }
+
             #[inline]
             fn visit_u64<E>(self, value: u64) -> Result<Value, E> {
                 Ok(Value::Number(value.into()))
+            }
+
+            fn visit_u128<E>(self, value: u128) -> Result<Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let de = serde::de::value::U128Deserializer::new(value);
+                Number::deserialize(de).map(Value::Number)
             }
 
             #[inline]
@@ -187,21 +203,72 @@ where
     }
 }
 
-fn visit_object<'de, V>(object: Map<String, Value>, visitor: V) -> Result<V::Value, Error>
-where
-    V: Visitor<'de>,
-{
-    let len = object.len();
-    let mut deserializer = MapDeserializer::new(object);
-    let map = tri!(visitor.visit_map(&mut deserializer));
-    let remaining = deserializer.iter.len();
-    if remaining == 0 {
-        Ok(map)
-    } else {
-        Err(serde::de::Error::invalid_length(
-            len,
-            &"fewer elements in map",
-        ))
+impl<'de> serde::Deserializer<'de> for Map<String, Value> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let len = self.len();
+        let mut deserializer = MapDeserializer::new(self);
+        let map = tri!(visitor.visit_map(&mut deserializer));
+        let remaining = deserializer.iter.len();
+        if remaining == 0 {
+            Ok(map)
+        } else {
+            Err(serde::de::Error::invalid_length(
+                len,
+                &"fewer elements in map",
+            ))
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let mut iter = self.into_iter();
+        let (variant, value) = match iter.next() {
+            Some(v) => v,
+            None => {
+                return Err(serde::de::Error::invalid_value(
+                    Unexpected::Map,
+                    &"map with a single key",
+                ));
+            }
+        };
+        // enums are encoded in json as maps with a single key:value pair
+        if iter.next().is_some() {
+            return Err(serde::de::Error::invalid_value(
+                Unexpected::Map,
+                &"map with a single key",
+            ));
+        }
+
+        visitor.visit_enum(EnumDeserializer {
+            variant,
+            value: Some(value),
+        })
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        drop(self);
+        visitor.visit_unit()
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct identifier
     }
 }
 
@@ -222,7 +289,7 @@ impl<'de> serde::Deserializer<'de> for Value {
             #[cfg(not(any(feature = "std", feature = "alloc")))]
             Value::String(_) => unreachable!(),
             Value::Array(v) => visit_array(v, visitor),
-            Value::Object(v) => visit_object(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
         }
     }
 
@@ -253,44 +320,24 @@ impl<'de> serde::Deserializer<'de> for Value {
     #[inline]
     fn deserialize_enum<V>(
         self,
-        _name: &str,
-        _variants: &'static [&'static str],
+        name: &'static str,
+        variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Error>
     where
         V: Visitor<'de>,
     {
-        let (variant, value) = match self {
-            Value::Object(value) => {
-                let mut iter = value.into_iter();
-                let (variant, value) = match iter.next() {
-                    Some(v) => v,
-                    None => {
-                        return Err(serde::de::Error::invalid_value(
-                            Unexpected::Map,
-                            &"map with a single key",
-                        ));
-                    }
-                };
-                // enums are encoded in json as maps with a single key:value pair
-                if iter.next().is_some() {
-                    return Err(serde::de::Error::invalid_value(
-                        Unexpected::Map,
-                        &"map with a single key",
-                    ));
-                }
-                (variant, Some(value))
-            }
-            Value::String(variant) => (variant, None),
-            other => {
-                return Err(serde::de::Error::invalid_type(
-                    other.unexpected(),
-                    &"string or map",
-                ));
-            }
-        };
-
-        visitor.visit_enum(EnumDeserializer { variant, value })
+        match self {
+            Value::Object(value) => value.deserialize_enum(name, variants, visitor),
+            Value::String(variant) => visitor.visit_enum(EnumDeserializer {
+                variant,
+                value: None,
+            }),
+            other => Err(serde::de::Error::invalid_type(
+                other.unexpected(),
+                &"string or map",
+            )),
+        }
     }
 
     #[inline]
@@ -420,7 +467,7 @@ impl<'de> serde::Deserializer<'de> for Value {
         V: Visitor<'de>,
     {
         match self {
-            Value::Object(v) => visit_object(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -436,7 +483,7 @@ impl<'de> serde::Deserializer<'de> for Value {
     {
         match self {
             Value::Array(v) => visit_array(v, visitor),
-            Value::Object(v) => visit_object(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -551,7 +598,7 @@ impl<'de> VariantAccess<'de> for VariantDeserializer {
         V: Visitor<'de>,
     {
         match self.value {
-            Some(Value::Object(v)) => visit_object(v, visitor),
+            Some(Value::Object(v)) => v.deserialize_any(visitor),
             Some(other) => Err(serde::de::Error::invalid_type(
                 other.unexpected(),
                 &"struct variant",
@@ -692,21 +739,71 @@ where
     }
 }
 
-fn visit_object_ref<'de, V>(object: &'de Map<String, Value>, visitor: V) -> Result<V::Value, Error>
-where
-    V: Visitor<'de>,
-{
-    let len = object.len();
-    let mut deserializer = MapRefDeserializer::new(object);
-    let map = tri!(visitor.visit_map(&mut deserializer));
-    let remaining = deserializer.iter.len();
-    if remaining == 0 {
-        Ok(map)
-    } else {
-        Err(serde::de::Error::invalid_length(
-            len,
-            &"fewer elements in map",
-        ))
+impl<'de> serde::Deserializer<'de> for &'de Map<String, Value> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let len = self.len();
+        let mut deserializer = MapRefDeserializer::new(self);
+        let map = tri!(visitor.visit_map(&mut deserializer));
+        let remaining = deserializer.iter.len();
+        if remaining == 0 {
+            Ok(map)
+        } else {
+            Err(serde::de::Error::invalid_length(
+                len,
+                &"fewer elements in map",
+            ))
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let mut iter = self.into_iter();
+        let (variant, value) = match iter.next() {
+            Some(v) => v,
+            None => {
+                return Err(serde::de::Error::invalid_value(
+                    Unexpected::Map,
+                    &"map with a single key",
+                ));
+            }
+        };
+        // enums are encoded in json as maps with a single key:value pair
+        if iter.next().is_some() {
+            return Err(serde::de::Error::invalid_value(
+                Unexpected::Map,
+                &"map with a single key",
+            ));
+        }
+
+        visitor.visit_enum(EnumRefDeserializer {
+            variant,
+            value: Some(value),
+        })
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct identifier
     }
 }
 
@@ -723,7 +820,7 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
             Value::Number(n) => n.deserialize_any(visitor),
             Value::String(v) => visitor.visit_borrowed_str(v),
             Value::Array(v) => visit_array_ref(v, visitor),
-            Value::Object(v) => visit_object_ref(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
         }
     }
 
@@ -752,44 +849,24 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
 
     fn deserialize_enum<V>(
         self,
-        _name: &str,
-        _variants: &'static [&'static str],
+        name: &'static str,
+        variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Error>
     where
         V: Visitor<'de>,
     {
-        let (variant, value) = match self {
-            Value::Object(value) => {
-                let mut iter = value.into_iter();
-                let (variant, value) = match iter.next() {
-                    Some(v) => v,
-                    None => {
-                        return Err(serde::de::Error::invalid_value(
-                            Unexpected::Map,
-                            &"map with a single key",
-                        ));
-                    }
-                };
-                // enums are encoded in json as maps with a single key:value pair
-                if iter.next().is_some() {
-                    return Err(serde::de::Error::invalid_value(
-                        Unexpected::Map,
-                        &"map with a single key",
-                    ));
-                }
-                (variant, Some(value))
-            }
-            Value::String(variant) => (variant, None),
-            other => {
-                return Err(serde::de::Error::invalid_type(
-                    other.unexpected(),
-                    &"string or map",
-                ));
-            }
-        };
-
-        visitor.visit_enum(EnumRefDeserializer { variant, value })
+        match self {
+            Value::Object(value) => value.deserialize_enum(name, variants, visitor),
+            Value::String(variant) => visitor.visit_enum(EnumRefDeserializer {
+                variant,
+                value: None,
+            }),
+            other => Err(serde::de::Error::invalid_type(
+                other.unexpected(),
+                &"string or map",
+            )),
+        }
     }
 
     #[inline]
@@ -917,7 +994,7 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
         V: Visitor<'de>,
     {
         match self {
-            Value::Object(v) => visit_object_ref(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -933,7 +1010,7 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     {
         match self {
             Value::Array(v) => visit_array_ref(v, visitor),
-            Value::Object(v) => visit_object_ref(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -1031,7 +1108,7 @@ impl<'de> VariantAccess<'de> for VariantRefDeserializer<'de> {
         V: Visitor<'de>,
     {
         match self.value {
-            Some(Value::Object(v)) => visit_object_ref(v, visitor),
+            Some(Value::Object(v)) => v.deserialize_any(visitor),
             Some(other) => Err(serde::de::Error::invalid_type(
                 other.unexpected(),
                 &"struct variant",

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -861,6 +861,32 @@ impl Value {
     pub fn take(&mut self) -> Value {
         mem::replace(self, Value::Null)
     }
+
+    /// Reorders the entries of all `Value::Object` nested within this JSON
+    /// value according to `str`'s usual ordering.
+    ///
+    /// If serde_json's "preserve_order" feature is not enabled, this method
+    /// does no work because all JSON maps are always kept in a sorted state.
+    ///
+    /// If serde_json's "preserve_order" feature is enabled, this method
+    /// destroys the original source order or insertion order of the JSON
+    /// objects in favor of an alphanumerical order that matches how a BTreeMap
+    /// with the same contents would be ordered.
+    pub fn sort_all_objects(&mut self) {
+        #[cfg(feature = "preserve_order")]
+        {
+            match self {
+                Value::Object(map) => {
+                    map.sort_keys();
+                    map.values_mut().for_each(Value::sort_all_objects);
+                }
+                Value::Array(list) => {
+                    list.iter_mut().for_each(Value::sort_all_objects);
+                }
+                _ => {}
+            }
+        }
+    }
 }
 
 /// The default value is `Value::Null`.

--- a/tests/ui/missing_comma.stderr
+++ b/tests/ui/missing_comma.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `"2"`
+error: no rules expected `"2"`
  --> tests/ui/missing_comma.rs:4:21
   |
 4 |     json!({ "1": "" "2": "" });

--- a/tests/ui/parse_expr.stderr
+++ b/tests/ui/parse_expr.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `~`
+error: no rules expected `~`
  --> tests/ui/parse_expr.rs:4:19
   |
 4 |     json!({ "a" : ~ });

--- a/tests/ui/unexpected_after_array_element.stderr
+++ b/tests/ui/unexpected_after_array_element.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `=>`
+error: no rules expected `=>`
  --> tests/ui/unexpected_after_array_element.rs:4:18
   |
 4 |     json!([ true => ]);

--- a/tests/ui/unexpected_after_map_entry.stderr
+++ b/tests/ui/unexpected_after_map_entry.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `=>`
+error: no rules expected `=>`
  --> tests/ui/unexpected_after_map_entry.rs:4:23
   |
 4 |     json!({ "k": true => });

--- a/tests/ui/unexpected_colon.stderr
+++ b/tests/ui/unexpected_colon.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `:`
+error: no rules expected `:`
  --> tests/ui/unexpected_colon.rs:4:13
   |
 4 |     json!({ : true });

--- a/tests/ui/unexpected_comma.stderr
+++ b/tests/ui/unexpected_comma.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `,`
+error: no rules expected `,`
  --> tests/ui/unexpected_comma.rs:4:17
   |
 4 |     json!({ "a" , "b": true });


### PR DESCRIPTION
This merges updates from upstream. There were substantial conflicts with ignoring trailing commas in `src/de.rs`. I defaulted to the upstream implementation, then re-added the trailing-commas support as well as using `EofWhileParsingObject` and `EofWhileParsingList` instead of `EofWhileParsingValue`.