### PR TITLE
Replace LoneLeadingSurrogateInHexEscape with U+FFFD

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -1262,7 +1262,7 @@ fn parse_unicode_escape<'de, R: Read<'de>>(
 
         if n2 < 0xDC00 || n2 > 0xDFFF {
             if validate {
-                return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
+                return error_or_replace(read, scratch, false, ErrorCode::LoneLeadingSurrogateInHexEscape);
             }
             push_wtf8_codepoint(n1 as u32, scratch);
             // If n2 is a leading surrogate, we need to restart.

--- a/tests/invalid_characters.rs
+++ b/tests/invalid_characters.rs
@@ -51,3 +51,10 @@ fn test_invalid_utf16_escape_sequence_lone_high_surrogate_precedes_escape() {
     let value: Value = from_slice_with_unicode_substitution(s).unwrap();
     assert_eq!(value, json!({"key": "value=\u{fffd}\"x"}));
 }
+
+#[test]
+fn test_lone_leading_surrogate_in_hex_escape_replaced() {
+    let s = r#"{"key": "\udbcb\u001e"}"#.as_bytes();
+    let value: Value = from_slice_with_unicode_substitution(s).unwrap();
+    assert_eq!(value, json!({"key": "\u{fffd}"}));
+}


### PR DESCRIPTION
I think this stray `error(..)` came in merging from upstream, and should have been changed to `error_or_replace`.

Should we think about renaming `error` to `error_no_replace` so that this will be an error next time?